### PR TITLE
backend: Fix formatting

### DIFF
--- a/server/backend/src/app.module.ts
+++ b/server/backend/src/app.module.ts
@@ -1,9 +1,6 @@
 import { Module } from '@nestjs/common';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
 import { CamerasModule } from './cameras/cameras.module';
-import { AuthModule } from './auth/auth.module';
 
 @Module({
   imports: [
@@ -13,6 +10,6 @@ import { AuthModule } from './auth/auth.module';
       autoLoadEntities: true,
     }),
     CamerasModule,
-    AuthModule],
+  ],
 })
 export class AppModule {}

--- a/server/backend/src/cameras/camera.entity.ts
+++ b/server/backend/src/cameras/camera.entity.ts
@@ -4,8 +4,8 @@ import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 @Entity()
 export class Camera {
   constructor(name: string, token: string) {
-    this.name! = name;
-    this.token! = token;
+    this.name = name;
+    this.token = token;
   }
 
   @PrimaryKey()

--- a/server/backend/src/cameras/cameras.controller.spec.ts
+++ b/server/backend/src/cameras/cameras.controller.spec.ts
@@ -18,7 +18,6 @@ const mockCamerasService = {
 
 describe('CamerasController', () => {
   let camerasController: CamerasController;
-  let camerasService: CamerasService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -32,7 +31,6 @@ describe('CamerasController', () => {
     }).compile();
 
     camerasController = module.get<CamerasController>(CamerasController);
-    camerasService = module.get<CamerasService>(CamerasService);
   });
 
   describe('PUT /cameras/' + validCamID + '/notification', () => {

--- a/server/backend/src/cameras/cameras.service.spec.ts
+++ b/server/backend/src/cameras/cameras.service.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { EntityRepository } from '@mikro-orm/core';
 import { getRepositoryToken } from '@mikro-orm/nestjs';
 import { CamerasService } from './cameras.service';
 import { Notification } from './notification.entity';
@@ -16,7 +15,9 @@ describe('CamerasService', () => {
   beforeEach(async () => {
     mockedNotificationRepository = {
       notifications: [Notification],
-      persist(notification: Notification) {},
+      persist: (notification: Notification) => {
+        return;
+      },
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -50,7 +51,7 @@ describe('CamerasService', () => {
 
   describe('sendNotification(validCamID)', () => {
     it('should add a new notification to the list', () => {
-      let notifications = [...mockedNotificationRepository.notifications];
+      const notifications = [...mockedNotificationRepository.notifications];
       camerasService.sendNotification(validCamID);
       expect(mockedNotificationRepository.notifications.length).toBe(
         notifications.length + 1,

--- a/server/backend/test/cameras.e2e-spec.ts
+++ b/server/backend/test/cameras.e2e-spec.ts
@@ -3,11 +3,9 @@ import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
 import { getRepositoryToken } from '@mikro-orm/nestjs';
 import { CamerasModule } from '../src/cameras/cameras.module';
-import { CamerasService } from '../src/cameras/cameras.service';
 import { Notification } from '../src/cameras/notification.entity';
 
 const validCameraID = '2cbc5197-65a5-4c8e-966a-bb168d1cfa67';
-const invalidCameraID = 'f48599ae-f4a5-4635-bd48-472b99f3ff62';
 const validToken = 'valid-bearer-token';
 const invalidToken = 'invalid-bearer-token';
 
@@ -19,7 +17,9 @@ describe('Cameras (e2e)', () => {
     /* FIXME: typescript. just define the MockNotificationRepository properly, extend the EntityRepository class */
     notificationRepository = {
       notifications: [new Notification()],
-      persist(notification: Notification) {},
+      persist: (notification: Notification) => {
+        return;
+      },
     };
     console.log(typeof notificationRepository);
     const moduleRef = await Test.createTestingModule({

--- a/server/backend/test/steps/send-notification.steps.ts
+++ b/server/backend/test/steps/send-notification.steps.ts
@@ -4,7 +4,6 @@ import { defineFeature, loadFeature } from 'jest-cucumber';
 import * as request from 'supertest';
 import { getRepositoryToken } from '@mikro-orm/nestjs';
 import { CamerasModule } from '../../src/cameras/cameras.module';
-import { CamerasService } from '../../src/cameras/cameras.service';
 import { Camera } from '../../src/cameras/camera.entity';
 import { Notification } from '../../src/cameras/notification.entity';
 
@@ -20,7 +19,9 @@ defineFeature(feature, (test) => {
     /* FIXME: typescript. just define the MockNotificationRepository properly, extend the EntityRepository class */
     notificationRepository = {
       notifications: [],
-      persist(notification: Notification) {},
+      persist: (notification: Notification) => {
+        return;
+      },
       findByCameraID(id: string): Notification[] {
         return [];
       },
@@ -130,7 +131,7 @@ defineFeature(feature, (test) => {
       expect(sendRes.status).toBe(401);
     });
     and('Camera B has 2 notifications', async () => {
-      let res = await request(app.getHttpServer())
+      const res = await request(app.getHttpServer())
         .get(requestURL)
         .auth(cameraB.token, { type: 'bearer' });
       expect(res.status).toBe(200);
@@ -147,7 +148,6 @@ defineFeature(feature, (test) => {
   }) => {
     const requestURL = `/cameras/${cameraA.id}/notifications`;
     let token: string;
-    let beforeNotifications: Notification[];
     let sendRes: request.Response;
 
     given("I have camera A's credentials", () => {
@@ -155,7 +155,6 @@ defineFeature(feature, (test) => {
     });
     and('Camera A has 1 notification', () => {
       notificationRepository.notifications = [new Notification()];
-      beforeNotifications = [...notificationRepository.notifications];
     });
     when('I try to send a notification on behalf of camera A', async () => {
       sendRes = await request(app.getHttpServer())
@@ -166,7 +165,7 @@ defineFeature(feature, (test) => {
       expect(sendRes.status).toBe(200);
     });
     and('Camera A has 2 notifications', async () => {
-      let res = await request(app.getHttpServer())
+      const res = await request(app.getHttpServer())
         .get(requestURL)
         .auth(token, { type: 'bearer' });
       expect(res.status).toBe(200);


### PR DESCRIPTION
# Notes
Some formatting issues were floating around because I was running straight Vim with no formatter before. The changes are minimal, but I figured I would rather have this in a separate PR rather than clutter the PRs I'll send out for the backend implementation.

# Testing
`npm run test` and `npm run lint`. There's still some unused variables, but most of those are from missing implementations and mocks that I plan on replacing later.