### PR TITLE
Add a helper for spawning a test stack

### DIFF
--- a/server/backend/src/cameras/camera.entity.ts
+++ b/server/backend/src/cameras/camera.entity.ts
@@ -9,6 +9,7 @@ import {
   UuidType,
 } from '@mikro-orm/core';
 import { Group } from '../groups/group.entity';
+import { Notification } from './notification.entity';
 
 @Entity()
 export class Camera {
@@ -23,6 +24,9 @@ export class Camera {
 
   @ManyToOne(() => Group)
   group: Group;
+
+  @OneToMany(() => Notification, (notification) => notification.camera)
+  notifications = new Collection<Notification>(this);
 
   constructor(name: string, token: string) {
     this.name = name;

--- a/server/backend/src/cameras/camera.entity.ts
+++ b/server/backend/src/cameras/camera.entity.ts
@@ -1,7 +1,9 @@
 import { v4 } from 'uuid';
 import {
+  Collection,
   Entity,
   ManyToOne,
+  OneToMany,
   PrimaryKey,
   Property,
   UuidType,
@@ -18,6 +20,9 @@ export class Camera {
 
   @Property()
   token!: string;
+
+  @ManyToOne(() => Group)
+  group: Group;
 
   constructor(name: string, token: string) {
     this.name = name;

--- a/server/backend/src/cameras/notification.entity.ts
+++ b/server/backend/src/cameras/notification.entity.ts
@@ -1,11 +1,22 @@
 import { v4 } from 'uuid';
-import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+import {
+  Entity,
+  ManyToOne,
+  PrimaryKey,
+  Property,
+  UuidType,
+} from '@mikro-orm/core';
+import { Camera } from '../cameras/camera.entity';
+import { TimestampType } from '../util';
 
 @Entity()
 export class Notification {
-  @PrimaryKey()
+  @PrimaryKey({ type: UuidType })
   id = v4();
 
-  @Property()
-  timestamp = new Date();
+  @Property({ type: TimestampType })
+  timestamp = Date();
+
+  @ManyToOne(() => Camera, { hidden: true })
+  camera!: Camera;
 }

--- a/server/backend/src/util/index.ts
+++ b/server/backend/src/util/index.ts
@@ -1,0 +1,1 @@
+export * from './timestamp.type';

--- a/server/backend/src/util/timestamp.type.ts
+++ b/server/backend/src/util/timestamp.type.ts
@@ -1,0 +1,21 @@
+import { DateTimeType, Platform } from '@mikro-orm/core';
+
+/**
+ * Represents an ISO8601 timestamp. MikroORM doesn't serialize Javascript Date objects as ISO8601
+ * by default, so a custom type is necessary.
+ */
+export class TimestampType extends DateTimeType {
+  convertToDatabaseValue(
+    value: string | Date,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    platform: Platform,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    fromQuery?: boolean,
+  ): string {
+    if (!(value instanceof Date)) {
+      value = new Date(value);
+    }
+
+    return value.toISOString();
+  }
+}

--- a/server/backend/test/helpers/test-stack.ts
+++ b/server/backend/test/helpers/test-stack.ts
@@ -1,0 +1,53 @@
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { Test, TestingModule } from '@nestjs/testing';
+import mikroOrmOptions from '../../mikro-orm.config';
+import {
+  PostgreSqlContainer,
+  StartedPostgreSqlContainer,
+} from 'testcontainers';
+import { MikroORM } from '@mikro-orm/core';
+import { ModuleMetadata } from '@nestjs/common';
+
+export interface TestStack {
+  module: TestingModule;
+  dbContainer: StartedPostgreSqlContainer;
+}
+
+/**
+ * Timeout for the 'beforeAll()' hook in Jest tests. Docker containers take some time to spin up,
+ * even more so if it needs to pull the image during setup.
+ */
+export const TEST_STACK_TIMEOUT = 30000;
+
+/**
+ * Builds a test instance of our Nest application with our dependencies (e.g. Postgres)
+ * running in Docker containers.
+ */
+export async function buildTestStack(
+  moduleMetadata: ModuleMetadata,
+): Promise<TestStack> {
+  const dbContainer = await new PostgreSqlContainer(
+    'postgres:14-alpine',
+  ).start();
+
+  const testModule = await Test.createTestingModule({
+    ...moduleMetadata,
+    imports: [
+      ...moduleMetadata.imports,
+      MikroOrmModule.forRoot({
+        ...mikroOrmOptions,
+        host: 'localhost',
+        dbName: dbContainer.getDatabase(),
+        user: dbContainer.getUsername(),
+        password: dbContainer.getPassword(),
+        port: dbContainer.getPort(),
+        allowGlobalContext: true,
+      }),
+    ],
+  }).compile();
+
+  const orm = testModule.get<MikroORM>(MikroORM);
+  await orm.getSchemaGenerator().createSchema();
+
+  return { module: testModule, dbContainer };
+}

--- a/server/backend/test/steps/send-notification.steps.ts
+++ b/server/backend/test/steps/send-notification.steps.ts
@@ -1,48 +1,45 @@
 import { INestApplication } from '@nestjs/common';
-import { Test } from '@nestjs/testing';
 import { defineFeature, loadFeature } from 'jest-cucumber';
 import * as request from 'supertest';
-import { getRepositoryToken } from '@mikro-orm/nestjs';
-import { CamerasModule } from '../../src/cameras/cameras.module';
 import { Camera } from '../../src/cameras/camera.entity';
 import { Notification } from '../../src/cameras/notification.entity';
+import {
+  buildTestStack,
+  TestStack,
+  TEST_STACK_TIMEOUT,
+} from '../helpers/test-stack';
+import { EntityManager, EntityRepository } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/core';
+import { v4 } from 'uuid';
+import { CamerasModule } from '../../src/cameras/cameras.module';
+import { Group } from '../../src/groups/group.entity';
+import { User } from '../../src/users/user.entity';
 
 const feature = loadFeature('test/features/send-notification.feature');
-const cameraA = new Camera('Cam-A', 'camera-A-token');
-const cameraB = new Camera('Cam-B', 'camera-B-token');
 
 defineFeature(feature, (test) => {
   let app: INestApplication;
-  let notificationRepository;
+  let testStack: TestStack;
+  let cameraRepository: EntityRepository<Camera>;
+  let em: EntityManager;
 
   beforeAll(async () => {
-    /* FIXME: typescript. just define the MockNotificationRepository properly, extend the EntityRepository class */
-    notificationRepository = {
-      notifications: [],
-      persist: (notification: Notification) => {
-        return;
-      },
-      findByCameraID(id: string): Notification[] {
-        return [];
-      },
-    };
-    const moduleRef = await Test.createTestingModule({
-      imports: [CamerasModule],
-    })
-      .overrideProvider(getRepositoryToken(Notification))
-      .useValue(notificationRepository)
-      .compile();
+    testStack = await buildTestStack({ imports: [CamerasModule] });
 
-    app = moduleRef.createNestApplication();
+    em = testStack.module.get<MikroORM>(MikroORM).em.fork();
+    cameraRepository = em.getRepository(Camera);
+
+    app = testStack.module.createNestApplication();
     await app.init();
-  });
+  }, TEST_STACK_TIMEOUT);
 
   afterAll(async () => {
     await app.close();
+    await testStack.dbContainer.stop();
   });
 
   test('Sending without credentials', ({ given, when, then, and }) => {
-    const requestURL = `/cameras/${cameraA.id}/notifications`;
+    let cameraA: Camera;
     let sendRes: request.Response;
     let beforeNotifications: Notification[];
     let token: string;
@@ -50,17 +47,17 @@ defineFeature(feature, (test) => {
     given('I have no credentials', () => {
       token = '';
     });
-    and('Camera A has 3 notifications', () => {
-      notificationRepository.notifications = [
-        new Notification(),
-        new Notification(),
-        new Notification(),
-      ];
-      beforeNotifications = [...notificationRepository.notifications];
+    and('Camera A has 3 notifications', async () => {
+      cameraA = new Camera('Camera-A', 'TODO');
+      cameraA.notifications.add(new Notification());
+      cameraA.group = new Group('g');
+      cameraA.group.user = new User('test');
+      await cameraRepository.persistAndFlush(cameraA);
+      beforeNotifications = cameraA.notifications.getItems();
     });
     when('I try to send a notification for camera A', async () => {
       sendRes = await request(app.getHttpServer())
-        .put(requestURL)
+        .put(`/cameras/${cameraA.id}/notifications`)
         .auth(token, { type: 'bearer' });
     });
     then("I receive an 'Unauthorized' error", () => {
@@ -68,7 +65,7 @@ defineFeature(feature, (test) => {
     });
     and('Camera A has 3 notifications', async () => {
       const res = await request(app.getHttpServer())
-        .get(requestURL)
+        .get(`/cameras/${cameraA.id}/notifications`)
         .auth(cameraA.token, { type: 'bearer' });
       expect(res.status).toBe(200);
       expect(res.header['content-type']).toMatch(/^application\/json/);
@@ -77,16 +74,24 @@ defineFeature(feature, (test) => {
   });
 
   test('Sending to an invalid camera ID', ({ given, when, then, and }) => {
-    const cameraCID = '6f9f4780-b688-4a9a-9eba-c07c0439e74f';
-    const requestURL = `/cameras/${cameraCID}/notifications`;
+    let cameraA: Camera;
+    const cameraCId = v4();
+    const requestURL = `/cameras/${cameraCId}/notifications`;
     let token: string;
     let sendRes: request.Response;
 
-    given("I have camera A's credentials", () => {
+    given("I have camera A's credentials", async () => {
+      cameraA = new Camera('CameraA', 'TODO :)');
+      cameraA.group = new Group('e');
+      cameraA.group.user = new User('eorwabk');
+      await cameraRepository.persistAndFlush(cameraA);
       token = cameraA.token;
     });
-    and('Camera C is not registered', () => {
-      /* TODO */
+    and('Camera C is not registered', async () => {
+      await request(app.getHttpServer())
+        .get(requestURL)
+        .auth(token, { type: 'bearer' })
+        .expect(401);
     });
     when("I try to send a notification using camera C's ID", async () => {
       sendRes = await request(app.getHttpServer())
@@ -96,8 +101,11 @@ defineFeature(feature, (test) => {
     then("I recieve an 'Unauthorized' error", () => {
       expect(sendRes.status).toBe(401);
     });
-    and('Camera C is not registered', () => {
-      /* TODO */
+    and('Camera C is not registered', async () => {
+      await request(app.getHttpServer())
+        .get(requestURL)
+        .auth(token, { type: 'bearer' })
+        .expect(401);
     });
   });
 
@@ -107,24 +115,30 @@ defineFeature(feature, (test) => {
     then,
     and,
   }) => {
-    const requestURL = `/cameras/${cameraB.id}/notifications`;
+    let cameraA: Camera;
+    let cameraB: Camera;
     let token: string;
     let beforeNotifications: Notification[];
     let sendRes: request.Response;
 
-    given("I have camera A's credentials", () => {
+    given("I have camera A's credentials", async () => {
+      cameraA = new Camera('Camera-A', 'TODO!! :)');
+      cameraA.group = new Group('g');
+      cameraA.group.user = new User('test');
+      await cameraRepository.persistAndFlush(cameraA);
       token = cameraA.token;
     });
-    and('Camera B has 2 notifications', () => {
-      notificationRepository.notifications = [
-        new Notification(),
-        new Notification(),
-      ];
-      beforeNotifications = [...notificationRepository.notifications];
+    and('Camera B has 2 notifications', async () => {
+      cameraB = new Camera('Camera-B', 'TODO KEYCLOAK AAAAA');
+      cameraB.notifications.add(new Notification(), new Notification());
+      cameraB.group = new Group('b');
+      cameraB.group.user = new User('g');
+      await cameraRepository.persistAndFlush(cameraB);
+      beforeNotifications = cameraB.notifications.getItems();
     });
     when('I try to send a notification on behalf of camera B', async () => {
       sendRes = await request(app.getHttpServer())
-        .put(requestURL)
+        .put(`/cameras/${cameraB.id}/notifications`)
         .auth(token, { type: 'bearer' });
     });
     then("I recieve an 'Unauthorized' error", () => {
@@ -132,7 +146,7 @@ defineFeature(feature, (test) => {
     });
     and('Camera B has 2 notifications', async () => {
       const res = await request(app.getHttpServer())
-        .get(requestURL)
+        .get(`/cameras/${cameraB.id}/notifications`)
         .auth(cameraB.token, { type: 'bearer' });
       expect(res.status).toBe(200);
       expect(res.header['content-type']).toMatch(/^application\/json/);
@@ -146,19 +160,24 @@ defineFeature(feature, (test) => {
     then,
     and,
   }) => {
-    const requestURL = `/cameras/${cameraA.id}/notifications`;
+    let cameraA: Camera;
     let token: string;
     let sendRes: request.Response;
 
-    given("I have camera A's credentials", () => {
+    given("I have camera A's credentials", async () => {
+      cameraA = new Camera('Camera-A', 'TODO !!!!!!!');
+      cameraA.group = new Group('group');
+      cameraA.group.user = new User('user');
+      await cameraRepository.persistAndFlush(cameraA);
       token = cameraA.token;
     });
-    and('Camera A has 1 notification', () => {
-      notificationRepository.notifications = [new Notification()];
+    and('Camera A has 1 notification', async () => {
+      cameraA.notifications.add(new Notification());
+      await cameraRepository.flush();
     });
     when('I try to send a notification on behalf of camera A', async () => {
       sendRes = await request(app.getHttpServer())
-        .put(requestURL)
+        .put(`/cameras/${cameraA.id}/notifications`)
         .auth(token, { type: 'bearer' });
     });
     then('The request succeeded', () => {
@@ -166,7 +185,7 @@ defineFeature(feature, (test) => {
     });
     and('Camera A has 2 notifications', async () => {
       const res = await request(app.getHttpServer())
-        .get(requestURL)
+        .get(`/cameras/${cameraA.id}/notifications`)
         .auth(token, { type: 'bearer' });
       expect(res.status).toBe(200);
       expect(res.header['content-type']).toMatch(/^application\/json/);


### PR DESCRIPTION
# Description
The backend's feature tests are full integration tests, so they spawn dependencies in Docker containers. This PR adds a helper for spawning the full stack and refactors the current set of feature tests to use this helper.

This helped the previously broken suite of tests for the `send-notification` feature to run again, but MikroORM had some issues with that and wasted my entire weekend. At least they work now though :)

# Testing
`npm test`