### PR TITLE
[EYE-51] Add endpoint for updating notification token

### DIFF
--- a/server/backend/src/users/user.entity.ts
+++ b/server/backend/src/users/user.entity.ts
@@ -17,6 +17,12 @@ export class User {
   @Property()
   name!: string;
 
+  // A user might not have a push notification:
+  // - After account registration
+  // - If they never allow notification permissions in the app
+  @Property({ nullable: true })
+  expoToken?: string;
+
   @OneToMany(() => Group, (group) => group.user)
   groups = new Collection<Group>(this);
 

--- a/server/backend/src/users/users.controller.ts
+++ b/server/backend/src/users/users.controller.ts
@@ -1,9 +1,11 @@
 import {
+  Body,
   Controller,
   ForbiddenException,
   Get,
   Inject,
   Param,
+  Put,
 } from '@nestjs/common';
 import { NotFoundError } from '../errors.types';
 import { UsersService } from './users.service';
@@ -33,6 +35,22 @@ export class UsersController {
           name: camera.name,
         })),
       }));
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        throw new ForbiddenException();
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  @Put(':id/notifyToken')
+  async updateNotifyToken(
+    @Param('id') id: string,
+    @Body('expoToken') notifyToken: string,
+  ): Promise<void> {
+    try {
+      await this.usersService.updateNotifyToken(id, notifyToken);
     } catch (error) {
       if (error instanceof NotFoundError) {
         throw new ForbiddenException();

--- a/server/backend/src/users/users.service.ts
+++ b/server/backend/src/users/users.service.ts
@@ -28,4 +28,22 @@ export class UsersService {
     }
     return user.groups;
   }
+
+  /**
+   * Update's the user's push notification token.
+   *
+   * @param userId the user's ID.
+   * @param notifyToken the new notification token.
+   */
+  public async updateNotifyToken(
+    userId: string,
+    notifyToken: string,
+  ): Promise<void> {
+    const user = await this.usersRepository.findOne({ id: userId });
+    if (user === null) {
+      throw new NotFoundError(`User with ID "${userId}" does not exist.`);
+    }
+    user.expoToken = notifyToken;
+    await this.usersRepository.flush();
+  }
 }

--- a/server/backend/test/features/update-push-token.feature
+++ b/server/backend/test/features/update-push-token.feature
@@ -1,0 +1,21 @@
+Feature: Updating a user's Expo push token
+
+  Scenario: Updating after login
+    Given I have a new Expo push token
+    And I am logged in
+    When I try to update my push token
+    Then It succeeds
+    And My push token has been updated
+
+  Scenario: Updating without credentials
+    Given I have a new Expo push token
+    And I am not logged in
+    When I try to update my push token
+    Then It fails with an unauthorized error
+    And My push token has not been updated
+
+  Scenario: Updating a non-existent user's token
+    Given I have a new Expo push token
+    And I have a bogus user ID
+    When I try to update their push token
+    Then It fails with an unauthorized error

--- a/server/backend/test/steps/update-push-token.steps.ts
+++ b/server/backend/test/steps/update-push-token.steps.ts
@@ -1,0 +1,116 @@
+import { EntityRepository, MikroORM } from '@mikro-orm/core';
+import { INestApplication } from '@nestjs/common';
+import { defineFeature, loadFeature } from 'jest-cucumber';
+import { User } from '../../src/users/user.entity';
+import { UsersModule } from '../../src/users/users.module';
+import {
+  buildTestStack,
+  TestStack,
+  TEST_STACK_TIMEOUT,
+} from '../helpers/test-stack';
+import * as request from 'supertest';
+import { v4 } from 'uuid';
+
+defineFeature(
+  loadFeature('test/features/update-push-token.feature'),
+  (test) => {
+    let app: INestApplication;
+    let testStack: TestStack;
+    let userRepository: EntityRepository<User>;
+
+    beforeAll(async () => {
+      testStack = await buildTestStack({ imports: [UsersModule] });
+
+      userRepository = testStack.module
+        .get<MikroORM>(MikroORM)
+        .em.getRepository(User);
+
+      app = await testStack.module.createNestApplication();
+      await app.init();
+    }, TEST_STACK_TIMEOUT);
+
+    afterAll(async () => {
+      await testStack.dbContainer.stop();
+      await app.close();
+    }, TEST_STACK_TIMEOUT);
+
+    test('Updating after login', ({ given, and, when, then }) => {
+      let expoToken: string;
+      let user: User;
+      let response: request.Response;
+
+      given('I have a new Expo push token', () => {
+        expoToken = 'push-token';
+      });
+      and('I am logged in', async () => {
+        user = new User('tester');
+        await userRepository.persistAndFlush(user);
+      });
+      when('I try to update my push token', async () => {
+        // TODO: auth
+        response = await request(app.getHttpServer())
+          .put(`/users/${user.id}/notifyToken`)
+          .send({ expoToken });
+      });
+      then('It succeeds', () => {
+        expect(response.statusCode).toBe(200);
+      });
+      and('My push token has been updated', async () => {
+        user = await userRepository.findOne({ id: user.id });
+        expect(user.expoToken).toBe(expoToken);
+      });
+    });
+
+    test('Updating without credentials', ({ given, and, when, then }) => {
+      let expoToken: string;
+      let user: User;
+      let response: request.Response;
+
+      given('I have a new Expo push token', () => {
+        expoToken = 'another-push-token';
+      });
+      and('I am not logged in', async () => {
+        user = new User('doofus');
+        await userRepository.persistAndFlush(user);
+      });
+      when('I try to update my push token', async () => {
+        response = await request(app.getHttpServer())
+          .put(`/users/${user.id}/notifyToken`)
+          .send({ expoToken });
+      });
+      then('It fails with an unauthorized error', () => {
+        expect(response.statusCode).toBe(403);
+      });
+      and('My push token has not been updated', async () => {
+        user = await userRepository.findOne({ id: user.id });
+        expect(user.expoToken).toBeUndefined();
+      });
+    });
+
+    test("Updating a non-existent user's token", ({
+      given,
+      and,
+      when,
+      then,
+    }) => {
+      let expoToken: string;
+      let userId: string;
+      let response: request.Response;
+
+      given('I have a new Expo push token', () => {
+        expoToken = 'yet-another-push-token';
+      });
+      and('I have a bogus user ID', () => {
+        userId = v4();
+      });
+      when('I try to update their push token', async () => {
+        response = await request(app.getHttpServer())
+          .put(`/users/${userId}/notifyToken`)
+          .send({ expoToken });
+      });
+      then('It fails with an unauthorized error', () => {
+        expect(response.statusCode).toBe(403);
+      });
+    });
+  },
+);


### PR DESCRIPTION
# Description
This implements the `/users/:id/notifyToken` endpoint needed by the mobile app for notification delivery.

# Testing
`npm test` (auth tests are failing, no Keycloak yet :sob:)