### PR TITLE
[EYE-43] Keycloak User Sync Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 # Ignore python virtual environment`
 **/.env
 **/.venv
+**/target/
+**/.idea/

--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ python src/main.py
 
 The below are installed when running `make install`:
 
-* Opencv-Python: OpenCV can read images and camera streams. Contains lots of computer vision functionality
-* Requests: HTTPS request library
-* Behave: Behavior tests
+- Opencv-Python: OpenCV can read images and camera streams. Contains lots of computer vision functionality
+- Requests: HTTPS request library
+- Behave: Behavior tests
 
 ## Mobile Application Tests
 
 To test the mobile application, you must have `node` and `npm` installed.
 
-To run the mobile application tests, when in the directory `/human-detector/app/human-detector-app/`, you can run `npm test`.  This command will both run unit tests, and behavior tests through jest and jest-cucumber.
+To run the mobile application tests, when in the directory `/human-detector/app/human-detector-app/`, you can run `npm test`. This command will both run unit tests, and behavior tests through jest and jest-cucumber.
 
 ```
 cd app/human-detector-app
@@ -96,3 +96,40 @@ Running tests for the backend requires installing `node` and `npm`.
 It may work with older versions, but it is confirmed working on NodeJS 16.5.1 LTS.
 Once you have `node` and `npm` installed, navigate to `server/backend` and follow
 the instructions in the README for testing.
+
+### Manual integration tests
+
+For full integration tests (like with the mobile app and camera), you can spawn
+a full test stack using [Docker](https://docs.docker.com/get-docker/). You'll need
+to set the following environment variables:
+
+1. `DB_NAME` - the name of the database (different from hostname)
+2. `DB_USER` - Postgres username
+3. `DB_PASSWORD` - the password
+
+For testing, you can set these to whatever you want. Setting them to something easy
+to type would be useful for your sanity if you want to connect to and inspect the
+database during testing.
+
+Some useful commands:
+
+- Build the containers for each component
+  ```sh
+  $ docker-compose build
+  ```
+- Run the test stack
+  ```sh
+  $ DB_NAME=... DB_USER=... DB_PASSWORD=... docker-compose up
+  ```
+- List running containers
+  ```sh
+  $ docker container ls
+  ```
+- Connect to the database
+  ```sh
+  $ docker exec -it ${POSTGRES_CONTAINER_NAME} psql -U ${DB_USER} ${DB_NAME}
+  ```
+- Clean up the resources created by `docker-compose`
+  ```sh
+  $ docker-compose down
+  ```

--- a/server/backend/.dockerignore
+++ b/server/backend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+Dockerfile

--- a/server/backend/Dockerfile
+++ b/server/backend/Dockerfile
@@ -1,0 +1,10 @@
+# syntax=docker/dockerfile:1
+FROM node:16-alpine AS builder
+WORKDIR /usr/src/app
+COPY package.json .
+COPY package-lock.json .
+RUN npm ci
+COPY . .
+RUN npm run build
+EXPOSE 3000
+CMD [ "npm", "run", "start:prod" ]

--- a/server/backend/src/users/user.entity.ts
+++ b/server/backend/src/users/user.entity.ts
@@ -15,7 +15,7 @@ export class User {
   id = v4();
 
   @Property()
-  name!: string;
+  name: string;
 
   // A user might not have a push notification:
   // - After account registration

--- a/server/database/init/01-create.sql
+++ b/server/database/init/01-create.sql
@@ -1,0 +1,18 @@
+set names 'utf8';
+set session_replication_role = 'replica';
+
+create table "user" ("id" uuid not null, "name" varchar(255), "expo_token" varchar(255) null, constraint "user_pkey" primary key ("id"));
+
+create table "group" ("id" uuid not null, "name" varchar(255) not null, "user_id" uuid not null, constraint "group_pkey" primary key ("id"));
+
+create table "camera" ("id" uuid not null, "name" varchar(255) not null, "token" varchar(255) not null, "group_id" uuid not null, constraint "camera_pkey" primary key ("id"));
+
+create table "notification" ("id" uuid not null, "timestamp" timestamptz(0) not null, "camera_id" uuid not null, constraint "notification_pkey" primary key ("id"));
+
+alter table "group" add constraint "group_user_id_foreign" foreign key ("user_id") references "user" ("id") on update cascade;
+
+alter table "camera" add constraint "camera_group_id_foreign" foreign key ("group_id") references "group" ("id") on update cascade;
+
+alter table "notification" add constraint "notification_camera_id_foreign" foreign key ("camera_id") references "camera" ("id") on update cascade;
+
+set session_replication_role = 'origin';

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -1,0 +1,33 @@
+version: "3"
+services:
+  backend:
+    build: ./backend
+    environment:
+      - DB_HOST=database
+      - DB_NAME
+      - DB_USER
+      - DB_PASSWORD
+    ports:
+      - "3000:3000"
+  database:
+    image: "postgres:14-alpine"
+    environment:
+      POSTGRES_USER: "${DB_USER}"
+      POSTGRES_PASSWORD: "${DB_PASSWORD}"
+      POSTGRES_DB: "${DB_NAME}"
+    expose:
+      - "5432"
+    volumes:
+      - ./database/init:/docker-entrypoint-initdb.d
+  keycloak:
+    build: ./keycloak
+    environment:
+      KEYCLOAK_ADMIN: "admin"
+      KEYCLOAK_ADMIN_PASSWORD: "admin"
+      SYNC_USERS_DB_HOST: database
+      SYNC_USERS_DB_NAME: "${DB_NAME}"
+      SYNC_USERS_DB_USER: "${DB_USER}"
+      SYNC_USERS_DB_PASSWORD: "${DB_PASSWORD}"
+    ports:
+      - "8080:8080"
+    command: ["start-dev"]

--- a/server/keycloak/Dockerfile
+++ b/server/keycloak/Dockerfile
@@ -1,0 +1,16 @@
+FROM maven:3.8-openjdk-18-slim AS spi-builder
+WORKDIR sync-users-spi
+RUN mkdir -p ./target
+# Utilize Docker cache; if pom.xml doesn't change, we don't need to re-fetch our deps
+COPY ./sync-users-spi/pom.xml .
+RUN mvn dependency:go-offline -B
+COPY ./sync-users-spi/src ./src
+RUN mvn package
+
+FROM quay.io/keycloak/keycloak:19.0.2 AS keycloak-builder
+COPY --from=spi-builder /sync-users-spi/target/sync-users.jar /opt/keycloak/providers
+RUN /opt/keycloak/bin/kc.sh build
+
+FROM quay.io/keycloak/keycloak:19.0.2
+COPY --from=keycloak-builder /opt/keycloak /opt/keycloak
+ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]

--- a/server/keycloak/Dockerfile
+++ b/server/keycloak/Dockerfile
@@ -9,6 +9,8 @@ RUN mvn package
 
 FROM quay.io/keycloak/keycloak:19.0.2 AS keycloak-builder
 COPY --from=spi-builder /sync-users-spi/target/sync-users.jar /opt/keycloak/providers
+COPY ./data/import /opt/keycloak/data/import
+RUN /opt/keycloak/bin/kc.sh -v import --dir /opt/keycloak/data/import
 RUN /opt/keycloak/bin/kc.sh build
 
 FROM quay.io/keycloak/keycloak:19.0.2

--- a/server/keycloak/data/import/user-realm.json
+++ b/server/keycloak/data/import/user-realm.json
@@ -1,0 +1,11 @@
+{
+  "realm": "users",
+  "enabled": true,
+  "registrationAllowed": true,
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "sync-users",
+    "jboss-logging"
+  ],
+  "keycloakVersion": "19.0.2"
+}

--- a/server/keycloak/sync-users-spi/pom.xml
+++ b/server/keycloak/sync-users-spi/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <properties>
+        <keycloak.version>19.0.2</keycloak.version>
+    </properties>
+
+    <groupId>org.eyespy</groupId>
+    <artifactId>sync_users_spi</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi-private</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.5.0.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.5.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>sync-users</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/server/keycloak/sync-users-spi/src/main/java/org/eyespy/keycloak/provider/ConfigProvider.java
+++ b/server/keycloak/sync-users-spi/src/main/java/org/eyespy/keycloak/provider/ConfigProvider.java
@@ -1,0 +1,7 @@
+package org.eyespy.keycloak.provider;
+
+import java.util.Optional;
+
+public interface ConfigProvider {
+    public Optional<String> get(String key);
+}

--- a/server/keycloak/sync-users-spi/src/main/java/org/eyespy/keycloak/provider/EnvironmentConfigProvider.java
+++ b/server/keycloak/sync-users-spi/src/main/java/org/eyespy/keycloak/provider/EnvironmentConfigProvider.java
@@ -1,0 +1,37 @@
+package org.eyespy.keycloak.provider;
+
+import java.util.Optional;
+
+/**
+ * Provide config values from the environment, converting "id-case" keys and prefixes to
+ * screaming snake-case (e.g. "ID_CASE").
+ */
+public class EnvironmentConfigProvider implements ConfigProvider{
+
+    private String prefix = "";
+
+    /**
+     * Convert "id-case" to screaming snake-case (e.g. "ID_CASE").
+     * @return the screaming snake-case string
+     */
+    private static String convertCase(String s) {
+        return s.replace("-", "_").toUpperCase();
+    }
+
+    public EnvironmentConfigProvider(String prefix) {
+        this.prefix = convertCase(prefix);
+    }
+
+    public Optional<String> get(String key) {
+        key = convertCase(key);
+        if (this.prefix != null && !this.prefix.isEmpty()) {
+            key = this.prefix + "_" + key;
+        }
+        String value = System.getenv(key);
+        if (value != null) {
+            return Optional.of(value);
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/server/keycloak/sync-users-spi/src/main/java/org/eyespy/keycloak/provider/PostgresqlUserStoreProvider.java
+++ b/server/keycloak/sync-users-spi/src/main/java/org/eyespy/keycloak/provider/PostgresqlUserStoreProvider.java
@@ -1,0 +1,90 @@
+package org.eyespy.keycloak.provider;
+
+import org.jboss.logging.Logger;
+
+import java.sql.*;
+import java.util.Properties;
+
+public class PostgresqlUserStoreProvider implements UserStoreProvider {
+
+    private static final String HOST_OPTION = "db-host";
+    private static final String DATABASE_OPTION = "db-name";
+    private static final String USER_OPTION = "db-user";
+    private static final String PASSWORD_OPTION = "db-password";
+    private static final String USERS_TABLE_OPTION = "db-users-table";
+    private static final String USER_ID_COLUMN_OPTION = "db-user-id-column";
+
+    // 'user' is a keyword in PostgreSQL, so we need to wrap it in double quotes for queries
+    private static final String DEFAULT_USERS_TABLE = "\"user\"";
+    private static final String DEFAULT_USER_ID_COLUMN = "id";
+
+    private String dbConnUrl;
+    private Properties dbConnProps;
+    private String usersTable = DEFAULT_USERS_TABLE;
+    private String userIdColumn = DEFAULT_USER_ID_COLUMN;
+    private static final Logger LOG = Logger.getLogger(PostgresqlUserStoreProvider.class);
+
+    private Connection getConnection() throws SQLException {
+        return DriverManager.getConnection(dbConnUrl, dbConnProps);
+    }
+
+    @Override
+    public void init(ConfigProvider configProvider) {
+        try {
+            /*
+             * FIXME: According to the Postgresql JDBC driver docs, this shouldn't be necessary for this Java version:
+             *        https://jdbc.postgresql.org/documentation/use/#loading-the-driver
+             *        However, I'm going insane and I just want my provider to work and this seems to do the job
+             *        for now because Keycloak comes bundled with a Postgresql JDBC driver. For some reason,
+             *        it won't expose it by default and I have to load it manually like this???
+             */
+            Class.forName("org.postgresql.Driver");
+        } catch (ClassNotFoundException exception) {
+            LOG.error("Postgresql driver not found", exception);
+        }
+        dbConnUrl = "jdbc:postgresql://" + configProvider.get(HOST_OPTION).orElse("localhost") + "/" + configProvider.get(DATABASE_OPTION).orElse("postgres");
+        dbConnProps = new Properties();
+
+        // Needed to allow saving user ID strings as UUID in Postgres: https://stackoverflow.com/a/66416520
+        dbConnProps.setProperty("stringtype", "unspecified");
+
+        dbConnProps.setProperty("user", configProvider.get(USER_OPTION).orElse("postgres"));
+        dbConnProps.setProperty("password", configProvider.get(PASSWORD_OPTION).orElse(""));
+        usersTable = configProvider.get(USERS_TABLE_OPTION).orElse(DEFAULT_USERS_TABLE);
+        userIdColumn = configProvider.get(USER_ID_COLUMN_OPTION).orElse(DEFAULT_USER_ID_COLUMN);
+
+        // Test connection now rather than surprising you with a failed connection later
+        try {
+            getConnection().close();
+        } catch (SQLException exception) {
+            LOG.error("Failed to connect to database (is your configuration correct?)", exception);
+        }
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void addUser(String userId) {
+        try (Connection conn = this.getConnection();
+             PreparedStatement stmt = conn.prepareStatement("INSERT INTO " + usersTable + " (" + userIdColumn + ") VALUES (?)")) {
+            stmt.setString(1, userId);
+            stmt.execute();
+            LOG.debugv("Added user with ID {0} to database", userId);
+        } catch (SQLException exception) {
+            LOG.error("Failed to add user to database", exception);
+        }
+    }
+
+    @Override
+    public void deleteUser(String userId) {
+        try (Connection conn = this.getConnection();
+             PreparedStatement stmt = conn.prepareStatement("DELETE FROM " + usersTable + " WHERE " + userIdColumn + " = ?")) {
+            stmt.setString(1, userId);
+            stmt.execute();
+            LOG.debugv("Deleted user with ID {0} from database", userId);
+        } catch (SQLException exception) {
+            LOG.error("Failed to delete user from database", exception);
+        }
+    }
+}

--- a/server/keycloak/sync-users-spi/src/main/java/org/eyespy/keycloak/provider/SyncUsersProvider.java
+++ b/server/keycloak/sync-users-spi/src/main/java/org/eyespy/keycloak/provider/SyncUsersProvider.java
@@ -1,0 +1,39 @@
+package org.eyespy.keycloak.provider;
+
+import org.jboss.logging.Logger;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.admin.AdminEvent;
+
+/**
+ * Synchronize user IDs to an external user store (e.g. an external database).
+ */
+public class SyncUsersProvider implements EventListenerProvider {
+
+    private final UserStoreProvider userStoreProvider;
+    private static final Logger LOG = Logger.getLogger(SyncUsersProvider.class);
+
+    public SyncUsersProvider(UserStoreProvider userStoreProvider) {
+        this.userStoreProvider = userStoreProvider;
+    }
+
+    @Override
+    public void onEvent(AdminEvent adminEvent, boolean b) {}
+    @Override
+    public void close() {
+        userStoreProvider.close();
+    }
+
+    @Override
+    public void onEvent(Event event) {
+        switch (event.getType()) {
+            case REGISTER:
+                LOG.infov("Adding new user with ID {0} to external store", event.getUserId());
+                this.userStoreProvider.addUser(event.getUserId());
+                break;
+            case DELETE_ACCOUNT:
+                LOG.infov("Removing user with ID {0} from external store", event.getUserId());
+                this.userStoreProvider.deleteUser(event.getUserId());
+        }
+    }
+}

--- a/server/keycloak/sync-users-spi/src/main/java/org/eyespy/keycloak/provider/SyncUsersProviderFactory.java
+++ b/server/keycloak/sync-users-spi/src/main/java/org/eyespy/keycloak/provider/SyncUsersProviderFactory.java
@@ -1,0 +1,43 @@
+package org.eyespy.keycloak.provider;
+
+import org.jboss.logging.Logger;
+import org.keycloak.Config;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventListenerProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+public class SyncUsersProviderFactory implements EventListenerProviderFactory {
+
+    private static final String PROVIDER_ID = "sync-users";
+
+    private UserStoreProvider userStoreProvider;
+    private static final Logger LOG = Logger.getLogger(SyncUsersProviderFactory.class);
+
+    @Override
+    public EventListenerProvider create(KeycloakSession keycloakSession) {
+        return new SyncUsersProvider(userStoreProvider);
+    }
+
+    @Override
+    public void init(Config.Scope scope) {
+        ConfigProvider configProvider = new EnvironmentConfigProvider(PROVIDER_ID);
+        userStoreProvider = new PostgresqlUserStoreProvider();
+        userStoreProvider.init(configProvider);
+        LOG.debug("Initialized user store");
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory keycloakSessionFactory) {}
+
+    @Override
+    public void close() {
+        this.userStoreProvider.close();
+        LOG.debug("Finished user store cleanup");
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/server/keycloak/sync-users-spi/src/main/java/org/eyespy/keycloak/provider/UserStoreProvider.java
+++ b/server/keycloak/sync-users-spi/src/main/java/org/eyespy/keycloak/provider/UserStoreProvider.java
@@ -1,0 +1,9 @@
+package org.eyespy.keycloak.provider;
+
+import org.keycloak.provider.Provider;
+
+public interface UserStoreProvider extends Provider {
+    void init(ConfigProvider configProvider);
+    void addUser(String userId);
+    void deleteUser(String userId);
+}

--- a/server/keycloak/sync-users-spi/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
+++ b/server/keycloak/sync-users-spi/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
@@ -1,0 +1,1 @@
+org.eyespy.keycloak.provider.SyncUsersProviderFactory


### PR DESCRIPTION
# Description
When a user registers through Keycloak, they are persisted in Keycloak's configured database, which isn't accessible from our Nest application. This leaves us with two options:

1. Point our Nest application and Keycloak at the same database
2. Synchronize users between our Keycloak and Nest databases

I thought option 2 would give us more flexibility when changing our user schemas (we won't have to worry about everything else Keycloak wants to store as well), and it would be simpler to set up the two if they just create different schemas in different databases. Keycloak seems to want it's own database, so I'll let it have one.

TODO before it's ready for review:
- [x] Automatically create `users` realm in Keycloak with the plugin enabled

# Testing
No unit tests exist because I had enough trouble and wasted enough time trying to get the thing to work properly. I set up a Docker Compose stack for the backend and did a basic manual test (registering a new user) to verify that the plugin works, and I don't foresee this plugin changing much so I think this should suffice.