### PR TITLE
Dev for access token mobile app

### DIFF
--- a/app/human-detector-app/App.tsx
+++ b/app/human-detector-app/App.tsx
@@ -29,7 +29,9 @@ export default function App(): React.ReactElement {
 
   React.useEffect(() => {
     if (isUserSignedIn) {
-      sendExpoNotifToken(user.userID).catch(() => console.error('Error in sending expo token!'));
+      sendExpoNotifToken(user.userID, tokenResponse.accessToken).catch(() =>
+        console.error('Error in sending expo token!')
+      );
     }
     console.log('print test');
   }, [isUserSignedIn]);
@@ -64,8 +66,6 @@ export default function App(): React.ReactElement {
 
   // Translates IDToken to a user
   const user = getUserFromIDToken(tokenResponse.idToken);
-
-  // If they just login, this useEffect will
 
   // If the user is logged in return the stack with all the information
   return (

--- a/app/human-detector-app/App.tsx
+++ b/app/human-detector-app/App.tsx
@@ -33,7 +33,6 @@ export default function App(): React.ReactElement {
         console.error('Error in sending expo token!')
       );
     }
-    console.log('print test');
   }, [isUserSignedIn]);
 
   // If the user isn't logged in

--- a/app/human-detector-app/__tests__/BackendService.test.ts
+++ b/app/human-detector-app/__tests__/BackendService.test.ts
@@ -11,6 +11,7 @@ import Notification from '../classes/Notification';
  */
 
 const nock = require('nock');
+const exampleAccessToken = 'ExampleAccessToken';
 
 // test putting notification key
 describe(BackendService.sendNotifyTokenAPI, () => {
@@ -20,7 +21,11 @@ describe(BackendService.sendNotifyTokenAPI, () => {
       .put(ServerConfig.getSendNotifKeyUrlExtension(newUser.userID))
       .reply(200, 'success');
 
-    await BackendService.sendNotifyTokenAPI(newUser.userID, 'ExponentPushToken[0000000000]');
+    await BackendService.sendNotifyTokenAPI(
+      newUser.userID,
+      'ExponentPushToken[0000000000]',
+      exampleAccessToken
+    );
   });
 
   it("should return code 401 if user id doesn't exist", async () => {
@@ -31,7 +36,11 @@ describe(BackendService.sendNotifyTokenAPI, () => {
       .reply(401, 'fail');
 
     await expect(
-      BackendService.sendNotifyTokenAPI(newUser.userID, 'ExponentPushToken[0000000000]')
+      BackendService.sendNotifyTokenAPI(
+        newUser.userID,
+        'ExponentPushToken[0000000000]',
+        exampleAccessToken
+      )
     ).rejects.toBe(errorMsg);
   });
 });

--- a/app/human-detector-app/__tests__/notifTokenInit.test.ts
+++ b/app/human-detector-app/__tests__/notifTokenInit.test.ts
@@ -10,6 +10,8 @@ jest.mock('expo-notifications');
 
 // Example user
 const user: User = new User('fjosejfoesf', '3232323', true);
+// Example access token
+const exampleAccessToken = 'ExampleAccessToken';
 
 // Permanent mocks
 beforeEach(() => {
@@ -31,7 +33,7 @@ describe('sendExpoNotifToken() iOS', () => {
     });
     BackendService.sendNotifyTokenAPI = jest.fn(() => Promise.resolve());
 
-    await sendExpoNotifToken(user.userID);
+    await sendExpoNotifToken(user.userID, exampleAccessToken);
     expect(helpers.isDevice).toHaveBeenCalledTimes(1);
     expect(helpers.getOS).toHaveBeenCalledTimes(1);
     expect(Notifications.getPermissionsAsync).toHaveBeenCalledTimes(1);
@@ -39,7 +41,8 @@ describe('sendExpoNotifToken() iOS', () => {
     expect(Notifications.requestPermissionsAsync).toHaveBeenCalledTimes(0);
     expect(BackendService.sendNotifyTokenAPI).toBeCalledWith(
       user.userID,
-      'ExponentPushToken[000000000000]'
+      'ExponentPushToken[000000000000]',
+      exampleAccessToken
     );
   });
 
@@ -52,7 +55,7 @@ describe('sendExpoNotifToken() iOS', () => {
     });
     BackendService.sendNotifyTokenAPI = jest.fn(() => Promise.resolve());
 
-    await sendExpoNotifToken(user.userID);
+    await sendExpoNotifToken(user.userID, exampleAccessToken);
     expect(helpers.isDevice).toHaveBeenCalledTimes(1);
     expect(helpers.getOS).toHaveBeenCalledTimes(1);
     expect(Notifications.getPermissionsAsync).toHaveBeenCalledTimes(1);
@@ -66,7 +69,9 @@ describe('sendExpoNotifToken() iOS', () => {
     Notifications.requestPermissionsAsync.mockResolvedValue({ status: 'denied' });
 
     const errorMsg = 'Failed to get push token for push notification!';
-    await expect(sendExpoNotifToken(user.userID)).rejects.toStrictEqual(new Error(errorMsg));
+    await expect(sendExpoNotifToken(user.userID, exampleAccessToken)).rejects.toStrictEqual(
+      new Error(errorMsg)
+    );
   });
 
   it('will return a reject if notifications are off', async () => {
@@ -77,7 +82,9 @@ describe('sendExpoNotifToken() iOS', () => {
     });
 
     const errorMsg = 'Failed to get push token for push notification!';
-    await expect(sendExpoNotifToken(user.userID)).rejects.toStrictEqual(new Error(errorMsg));
+    await expect(sendExpoNotifToken(user.userID, exampleAccessToken)).rejects.toStrictEqual(
+      new Error(errorMsg)
+    );
   });
 
   it('will return a reject with error message error in sending to server', async () => {
@@ -87,7 +94,9 @@ describe('sendExpoNotifToken() iOS', () => {
     ); // Sending to server error
 
     const errorMsg = 'Placeholder Error';
-    await expect(sendExpoNotifToken(user.userID)).rejects.toStrictEqual(new Error(errorMsg));
+    await expect(sendExpoNotifToken(user.userID, exampleAccessToken)).rejects.toStrictEqual(
+      new Error(errorMsg)
+    );
   });
 
   it('will return a reject if there is an error with getting the ExpoPushToken from the user', async () => {
@@ -97,7 +106,9 @@ describe('sendExpoNotifToken() iOS', () => {
     ); // Getting from the user error
 
     const errorMsg = 'Placeholder Error for Test 4';
-    await expect(sendExpoNotifToken(user.userID)).rejects.toStrictEqual(new Error(errorMsg));
+    await expect(sendExpoNotifToken(user.userID, exampleAccessToken)).rejects.toStrictEqual(
+      new Error(errorMsg)
+    );
   });
 });
 
@@ -112,7 +123,7 @@ describe('sendExpoNotifToken() android', () => {
     });
     BackendService.sendNotifyTokenAPI = jest.fn(() => Promise.resolve());
 
-    await sendExpoNotifToken(user.userID);
+    await sendExpoNotifToken(user.userID, exampleAccessToken);
     expect(helpers.isDevice).toHaveBeenCalledTimes(1);
     expect(helpers.getOS).toHaveBeenCalledTimes(1);
     expect(Notifications.getPermissionsAsync).toHaveBeenCalledTimes(1);

--- a/app/human-detector-app/services/backendService.ts
+++ b/app/human-detector-app/services/backendService.ts
@@ -8,7 +8,7 @@ import * as ServerUrl from '../config/ServerConfig';
  * This file handles HTTP requests to our backend
  */
 
-const BEARER_ = 'Bearer ';
+const BEARER = 'Bearer ';
 
 /**
  * This method is used to get the group list that is connected to a user.  This group list
@@ -43,6 +43,7 @@ export async function getGroupListAPI(userId: string): Promise<Group[] | null> {
  *
  * @param userIdFromLogin : userId of the user that just logged in
  * @param expoTokenFromLogin : notification token of the user that just logged in
+ * @param userAccessToken : the users access token for bearer authroization
  * @returns void if success, else it will return the error message
  */
 export async function sendNotifyTokenAPI(
@@ -53,7 +54,7 @@ export async function sendNotifyTokenAPI(
   try {
     const config = {
       headers: {
-        Authorization: BEARER_ + userAccessToken,
+        Authorization: BEARER + userAccessToken,
         'Content-Type': 'application/json',
         Accept: 'application/json',
       },

--- a/app/human-detector-app/services/backendService.ts
+++ b/app/human-detector-app/services/backendService.ts
@@ -8,6 +8,8 @@ import * as ServerUrl from '../config/ServerConfig';
  * This file handles HTTP requests to our backend
  */
 
+const BEARER_ = 'Bearer ';
+
 /**
  * This method is used to get the group list that is connected to a user.  This group list
  * will contain cameras and other information that will be stored as a group object.
@@ -16,6 +18,7 @@ import * as ServerUrl from '../config/ServerConfig';
  * @returns null if error occurs.
  *          An array of Groups that are owned by the user with the userId.
  */
+
 export async function getGroupListAPI(userId: string): Promise<Group[] | null> {
   try {
     const apiLinkWithExtension: string =
@@ -44,11 +47,13 @@ export async function getGroupListAPI(userId: string): Promise<Group[] | null> {
  */
 export async function sendNotifyTokenAPI(
   userIdFromLogin: string,
-  expoTokenFromLogin: string
+  expoTokenFromLogin: string,
+  userAccessToken: string
 ): Promise<void> {
   try {
     const config = {
       headers: {
+        Authorization: BEARER_ + userAccessToken,
         'Content-Type': 'application/json',
         Accept: 'application/json',
       },

--- a/app/human-detector-app/src/notifications/notifTokenInit.ts
+++ b/app/human-detector-app/src/notifications/notifTokenInit.ts
@@ -53,15 +53,17 @@ export async function getExponentPushToken(): Promise<string> {
  * This method will handle sending a users expo token
  * to the backend for push notifications.
  *
+ * @param userId The users user id
+ * @param accessToken The users access token for bearer auth
  * @returns a rejected Promise if something went wrong when retrieving or sending the expo token
  */
 // eslint-disable-next-line import/prefer-default-export
-export async function sendExpoNotifToken(userId: string): Promise<void> {
+export async function sendExpoNotifToken(userId: string, accessToken: string): Promise<void> {
   try {
     // Get the token from the user device
     const token = await getExponentPushToken();
     // Send the token if success
-    await sendNotifyTokenAPI(userId, token);
+    await sendNotifyTokenAPI(userId, token, accessToken);
   } catch (error) {
     // If any error occurs, reject out
     console.error(error.message);


### PR DESCRIPTION
# Description

This PR has changes so that the user will use the authorization header when sending an expo notification token.

** Other endpoints will have these changes in a separate PR.  We are just focusing on notifications to prepare for demo **

# Testing

Local testing showed that we had the function passing the access token to the http request.
All other tests have been changed to include the access token parameter and pass for both sendNotifyTokenAPI and notif token init functions.