### PR TITLE
backend: Add stub heartbeat endpoint

### DIFF
--- a/server/backend/src/cameras/cameras.controller.spec.ts
+++ b/server/backend/src/cameras/cameras.controller.spec.ts
@@ -56,4 +56,10 @@ describe('CamerasController', () => {
       }).toThrow(BadRequestException);
     });
   });
+
+  describe('PUT /cameras/' + validCamID + '/heartbeat', () => {
+    it('should return 200 OK', () => {
+      expect(camerasController.heartbeat(validCamID)).toBe('');
+    });
+  });
 });

--- a/server/backend/src/cameras/cameras.controller.ts
+++ b/server/backend/src/cameras/cameras.controller.ts
@@ -17,4 +17,10 @@ export class CamerasController {
   getNotifications(@Param('id') id: string): Notification[] {
     return this.camerasService.getNotifications(id);
   }
+
+  // FIXME: do the cameras need to send a heartbeat?
+  @Put(':id/heartbeat')
+  heartbeat(@Param('id') id: string) {
+    return '';
+  }
 }


### PR DESCRIPTION
# Description
We need a heartbeat endpoint so the camera won't die. We should probably talk later about whether we should keep it or add the feature to the app, but we need it for demo so here's a stub.

# Testing
- `npm test`