### PR TITLE
[EYE-43] Camera authorization

### DIFF
--- a/server/backend/package-lock.json
+++ b/server/backend/package-lock.json
@@ -25,6 +25,8 @@
         "ts-node": "^10.0.0"
       },
       "devDependencies": {
+        "@golevelup/ts-jest": "^0.3.3",
+        "@jest-mock/express": "^2.0.1",
         "@keycloak/keycloak-admin-client": "^18.0.2",
         "@mikro-orm/cli": "^5.1.5",
         "@nestjs/cli": "^8.0.0",
@@ -36,7 +38,6 @@
         "@types/supertest": "^2.0.11",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
-        "axios-debug-log": "^0.8.4",
         "dotenv": "^16.0.3",
         "eslint": "^8.0.1",
         "eslint-config-prettier": "^8.3.0",
@@ -875,6 +876,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "node_modules/@golevelup/ts-jest": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@golevelup/ts-jest/-/ts-jest-0.3.3.tgz",
+      "integrity": "sha512-gut5EhD2S7W1p+C/IsUS1o0P5SHgxsN9TqHyRTjG+rfycniLNBfvIWZPEizpsTev/lR10/XOTpE0YicxPme2+Q==",
+      "dev": true
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -949,6 +956,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@jest-mock/express": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@jest-mock/express/-/express-2.0.1.tgz",
+      "integrity": "sha512-DvW4WMGoNBEOGx1XRCe8yZyQ7ju5dWmBN57H0zPio7AqQo27QawI+o30f9xVdLnS0bAF2wbmQQfS61LxL/t8bQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "^4.17.13"
       }
     },
     "node_modules/@jest/console": {
@@ -2306,15 +2322,6 @@
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
     },
-    "node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dev": true,
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
     "node_modules/@types/docker-modem": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.2.tgz",
@@ -2470,12 +2477,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-      "dev": true
-    },
-    "node_modules/@types/ms": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -3302,19 +3303,6 @@
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios-debug-log": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/axios-debug-log/-/axios-debug-log-0.8.4.tgz",
-      "integrity": "sha512-DvmaJiYusndhfAjQ94HqlvhaVoEjOetwo9cpb+OVtOZNZTqdz0VAVed3ZjSQKpyM1g8jDXUXFx0Pg1DhUZzAdw==",
-      "dev": true,
-      "dependencies": {
-        "@types/debug": "^4.0.0",
-        "debug": "^4.0.0"
-      },
-      "peerDependencies": {
-        "axios": ">=0.17.0"
       }
     },
     "node_modules/babel-jest": {
@@ -15564,6 +15552,12 @@
         }
       }
     },
+    "@golevelup/ts-jest": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@golevelup/ts-jest/-/ts-jest-0.3.3.tgz",
+      "integrity": "sha512-gut5EhD2S7W1p+C/IsUS1o0P5SHgxsN9TqHyRTjG+rfycniLNBfvIWZPEizpsTev/lR10/XOTpE0YicxPme2+Q==",
+      "dev": true
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -15626,6 +15620,15 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
+    },
+    "@jest-mock/express": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@jest-mock/express/-/express-2.0.1.tgz",
+      "integrity": "sha512-DvW4WMGoNBEOGx1XRCe8yZyQ7ju5dWmBN57H0zPio7AqQo27QawI+o30f9xVdLnS0bAF2wbmQQfS61LxL/t8bQ==",
+      "dev": true,
+      "requires": {
+        "@types/express": "^4.17.13"
+      }
     },
     "@jest/console": {
       "version": "28.1.0",
@@ -16548,15 +16551,6 @@
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
     },
-    "@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dev": true,
-      "requires": {
-        "@types/ms": "*"
-      }
-    },
     "@types/docker-modem": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.2.tgz",
@@ -16712,12 +16706,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-      "dev": true
-    },
-    "@types/ms": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "@types/node": {
@@ -17361,16 +17349,6 @@
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "axios-debug-log": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/axios-debug-log/-/axios-debug-log-0.8.4.tgz",
-      "integrity": "sha512-DvmaJiYusndhfAjQ94HqlvhaVoEjOetwo9cpb+OVtOZNZTqdz0VAVed3ZjSQKpyM1g8jDXUXFx0Pg1DhUZzAdw==",
-      "dev": true,
-      "requires": {
-        "@types/debug": "^4.0.0",
-        "debug": "^4.0.0"
       }
     },
     "babel-jest": {

--- a/server/backend/package.json
+++ b/server/backend/package.json
@@ -32,6 +32,8 @@
     "ts-node": "^10.0.0"
   },
   "devDependencies": {
+    "@golevelup/ts-jest": "^0.3.3",
+    "@jest-mock/express": "^2.0.1",
     "@keycloak/keycloak-admin-client": "^18.0.2",
     "@mikro-orm/cli": "^5.1.5",
     "@nestjs/cli": "^8.0.0",

--- a/server/backend/src/cameras/camera-auth.guard.spec.ts
+++ b/server/backend/src/cameras/camera-auth.guard.spec.ts
@@ -1,0 +1,169 @@
+import { CameraAuthGuard } from './camera-auth.guard';
+import { CamerasService } from './cameras.service';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import {
+  ExecutionContext,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { sign, generateKeyPairSync, verify } from 'crypto';
+import { getMockReq } from '@jest-mock/express';
+import { v4 } from 'uuid';
+import { stringToBytes } from '../util';
+import { Request } from 'express';
+import { NotFoundError } from '../errors.types';
+
+/**
+ * Create a mock HTTP execution context that will return a request with the given parameters.
+ */
+function createMockHttpExecutionContext(
+  requestOptions?: Parameters<typeof getMockReq>[0],
+): DeepMocked<ExecutionContext> {
+  // '@jest-mock/express' doesn't provide a default header() implementation,
+  // so we need to do that ourselves if we want to pass headers as a dict
+  if (requestOptions && requestOptions.headers && !requestOptions.header) {
+    const mockHeader = jest.fn() as jest.MockedFunction<Request['header']>;
+    mockHeader.mockImplementation((name) => {
+      const header: string | string[] | undefined =
+        requestOptions.headers[name.toLowerCase()];
+      if (header === undefined) {
+        return undefined;
+      } else if (typeof header === 'string') {
+        return header;
+      } else {
+        return header[0];
+      }
+    });
+    requestOptions.header = mockHeader as jest.Mock;
+  }
+  const mockReq = getMockReq(requestOptions);
+  const mockExecutionContext = createMock<ExecutionContext>();
+  mockExecutionContext.switchToHttp.mockReturnValueOnce({
+    getRequest: <T = any>() => mockReq as unknown as T,
+    getNext: () => undefined,
+    getResponse: () => undefined,
+  });
+  return mockExecutionContext;
+}
+
+describe(CameraAuthGuard, () => {
+  it('should approve requests with valid keys', async () => {
+    const mockCamerasService = createMock<CamerasService>();
+    const cameraAuthGuard = new CameraAuthGuard(mockCamerasService);
+
+    const cameraId = v4();
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+    mockCamerasService.getPublicKey.mockResolvedValueOnce(
+      publicKey.export({ format: 'pem', type: 'spki' }).toString(),
+    );
+    const signature = sign(
+      undefined,
+      stringToBytes(cameraId),
+      privateKey,
+    ).toString('base64');
+    expect(
+      verify(
+        undefined,
+        stringToBytes(cameraId),
+        publicKey,
+        Buffer.from(signature, 'base64'),
+      ),
+    ).toBe(true);
+    const mockExecutionContext = createMockHttpExecutionContext({
+      params: { id: cameraId },
+      headers: { authorization: signature },
+    });
+    expect(cameraAuthGuard.canActivate(mockExecutionContext)).resolves.toBe(
+      true,
+    );
+    expect(mockCamerasService.getPublicKey).toBeCalledTimes(1);
+  });
+
+  it('should approve requests without auth to endpoints with no camera ID', () => {
+    const mockCamerasService = createMock<CamerasService>();
+    const cameraAuthGuard = new CameraAuthGuard(mockCamerasService);
+    const mockExecutionContext = createMockHttpExecutionContext();
+
+    expect(cameraAuthGuard.canActivate(mockExecutionContext)).resolves.toBe(
+      true,
+    );
+  });
+
+  it('should not approve requests to protected endpoints made without auth', () => {
+    const mockCamerasService = createMock<CamerasService>();
+    const cameraAuthGuard = new CameraAuthGuard(mockCamerasService);
+    const mockExecutionContext = createMockHttpExecutionContext({
+      params: { id: v4() },
+    });
+
+    expect(cameraAuthGuard.canActivate(mockExecutionContext)).rejects.toEqual(
+      new UnauthorizedException(),
+    );
+  });
+
+  it("should not approve requests made with another cameras's credentials", () => {
+    const attackerKeyPair = generateKeyPairSync('ed25519');
+    const realKeyPair = generateKeyPairSync('ed25519');
+    const cameraId = v4();
+
+    const mockCamerasService = createMock<CamerasService>();
+    const cameraAuthGuard = new CameraAuthGuard(mockCamerasService);
+    const signature = sign(
+      undefined,
+      stringToBytes(cameraId),
+      attackerKeyPair.privateKey,
+    ).toString('base64');
+    const mockExecutionContext = createMockHttpExecutionContext({
+      params: { id: v4() },
+      headers: { authorization: signature },
+    });
+    mockCamerasService.getPublicKey.mockResolvedValueOnce(
+      realKeyPair.publicKey.export({ format: 'pem', type: 'spki' }).toString(),
+    );
+
+    expect(cameraAuthGuard.canActivate(mockExecutionContext)).rejects.toEqual(
+      new ForbiddenException(),
+    );
+  });
+
+  it('should not approve requests for unregistered camera IDs', () => {
+    const attackerKeyPair = generateKeyPairSync('ed25519');
+    const bogusCameraId = v4();
+
+    const mockCamerasService = createMock<CamerasService>();
+    const cameraAuthGuard = new CameraAuthGuard(mockCamerasService);
+    const signature = sign(
+      undefined,
+      stringToBytes(bogusCameraId),
+      attackerKeyPair.privateKey,
+    ).toString('base64');
+    const mockExecutionContext = createMockHttpExecutionContext({
+      params: { id: v4() },
+      headers: { authorization: signature },
+    });
+    mockCamerasService.getPublicKey.mockRejectedValueOnce(
+      new NotFoundError(`Camera with ID ${bogusCameraId} does not exist`),
+    );
+
+    expect(cameraAuthGuard.canActivate(mockExecutionContext)).rejects.toEqual(
+      new ForbiddenException(),
+    );
+  });
+
+  it('should not approve requests with junk authorization', () => {
+    const mockCamerasService = createMock<CamerasService>();
+    const cameraAuthGuard = new CameraAuthGuard(mockCamerasService);
+    const mockExecutionContext = createMockHttpExecutionContext({
+      params: { id: v4() },
+      headers: { authorization: 'bogus' },
+    });
+    const { publicKey } = generateKeyPairSync('ed25519');
+    mockCamerasService.getPublicKey.mockRejectedValueOnce(
+      publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+    );
+
+    expect(cameraAuthGuard.canActivate(mockExecutionContext)).rejects.toEqual(
+      new ForbiddenException(),
+    );
+  });
+});

--- a/server/backend/src/cameras/camera-auth.guard.spec.ts
+++ b/server/backend/src/cameras/camera-auth.guard.spec.ts
@@ -1,50 +1,12 @@
 import { CameraAuthGuard } from './camera-auth.guard';
 import { CamerasService } from './cameras.service';
-import { createMock, DeepMocked } from '@golevelup/ts-jest';
-import {
-  ExecutionContext,
-  ForbiddenException,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { createMock } from '@golevelup/ts-jest';
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import { sign, generateKeyPairSync, verify } from 'crypto';
-import { getMockReq } from '@jest-mock/express';
 import { v4 } from 'uuid';
 import { stringToBytes } from '../util';
-import { Request } from 'express';
 import { NotFoundError } from '../errors.types';
-
-/**
- * Create a mock HTTP execution context that will return a request with the given parameters.
- */
-function createMockHttpExecutionContext(
-  requestOptions?: Parameters<typeof getMockReq>[0],
-): DeepMocked<ExecutionContext> {
-  // '@jest-mock/express' doesn't provide a default header() implementation,
-  // so we need to do that ourselves if we want to pass headers as a dict
-  if (requestOptions && requestOptions.headers && !requestOptions.header) {
-    const mockHeader = jest.fn() as jest.MockedFunction<Request['header']>;
-    mockHeader.mockImplementation((name) => {
-      const header: string | string[] | undefined =
-        requestOptions.headers[name.toLowerCase()];
-      if (header === undefined) {
-        return undefined;
-      } else if (typeof header === 'string') {
-        return header;
-      } else {
-        return header[0];
-      }
-    });
-    requestOptions.header = mockHeader as jest.Mock;
-  }
-  const mockReq = getMockReq(requestOptions);
-  const mockExecutionContext = createMock<ExecutionContext>();
-  mockExecutionContext.switchToHttp.mockReturnValueOnce({
-    getRequest: <T = any>() => mockReq as unknown as T,
-    getNext: () => undefined,
-    getResponse: () => undefined,
-  });
-  return mockExecutionContext;
-}
+import { createMockHttpExecutionContext } from '../../test/helpers/execution-context';
 
 describe(CameraAuthGuard, () => {
   it('should approve requests with valid keys', async () => {

--- a/server/backend/src/cameras/camera-auth.guard.spec.ts
+++ b/server/backend/src/cameras/camera-auth.guard.spec.ts
@@ -41,13 +41,13 @@ describe(CameraAuthGuard, () => {
     expect(mockCamerasService.getPublicKey).toBeCalledTimes(1);
   });
 
-  it('should approve requests without auth to endpoints with no camera ID', () => {
+  it('should reject any request to endpoints with no camera ID', () => {
     const mockCamerasService = createMock<CamerasService>();
     const cameraAuthGuard = new CameraAuthGuard(mockCamerasService);
     const mockExecutionContext = createMockHttpExecutionContext();
 
     expect(cameraAuthGuard.canActivate(mockExecutionContext)).resolves.toBe(
-      true,
+      false,
     );
   });
 

--- a/server/backend/src/cameras/camera-auth.guard.ts
+++ b/server/backend/src/cameras/camera-auth.guard.ts
@@ -10,6 +10,12 @@ import { CamerasService } from './cameras.service';
 import { verify } from 'crypto';
 import { stringToBytes } from '../util';
 
+/**
+ * Require cameras to present their signed ID.
+ *
+ * Note: any route using this guard must have an ID parameter (e.g. '/cameras/:id/notifications')
+ * or every request will be rejected.
+ */
 @Injectable()
 export class CameraAuthGuard implements CanActivate {
   constructor(private cameraService: CamerasService) {}
@@ -18,7 +24,7 @@ export class CameraAuthGuard implements CanActivate {
     const request = context.switchToHttp().getRequest<Request>();
     const id = request.params['id'];
     if (id === undefined) {
-      return true;
+      return false;
     }
     const signature = request.header('Authorization');
     if (signature === undefined) {

--- a/server/backend/src/cameras/camera.entity.ts
+++ b/server/backend/src/cameras/camera.entity.ts
@@ -19,6 +19,7 @@ export class Camera {
   @Property()
   name!: string;
 
+  // PEM-encoded public key
   @Property()
   token!: string;
 

--- a/server/backend/src/cameras/cameras.controller.spec.ts
+++ b/server/backend/src/cameras/cameras.controller.spec.ts
@@ -1,8 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import {
+  BadRequestException,
+  CanActivate,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { CamerasController } from './cameras.controller';
 import { CamerasService } from './cameras.service';
 import { Notification } from './notification.entity';
+import { CameraAuthGuard } from './camera-auth.guard';
 
 const validCamID = '4df87db2-d185-4126-8570-28bec04c1b16';
 const invalidCamID = '9a988948-450d-4627-bf51-ee4a94f4d5bf';
@@ -20,11 +25,18 @@ describe('CamerasController', () => {
   let camerasController: CamerasController;
 
   beforeEach(async () => {
+    const mockCameraAuthGuard: CanActivate = {
+      canActivate: () => Promise.resolve(true),
+    };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         {
           provide: CamerasService,
           useValue: mockCamerasService,
+        },
+        {
+          provide: CameraAuthGuard,
+          useValue: mockCameraAuthGuard,
         },
       ],
       controllers: [CamerasController],

--- a/server/backend/src/cameras/cameras.controller.ts
+++ b/server/backend/src/cameras/cameras.controller.ts
@@ -1,8 +1,10 @@
-import { Get, Put, Param, Controller } from '@nestjs/common';
+import { Get, Put, Param, Controller, UseGuards } from '@nestjs/common';
+import { CameraAuthGuard } from './camera-auth.guard';
 import { CamerasService } from './cameras.service';
 import { Notification } from './notification.entity';
 
 @Controller('cameras')
+@UseGuards(CameraAuthGuard)
 export class CamerasController {
   constructor(private camerasService: CamerasService) {}
 

--- a/server/backend/src/cameras/cameras.module.ts
+++ b/server/backend/src/cameras/cameras.module.ts
@@ -4,10 +4,11 @@ import { CamerasController } from './cameras.controller';
 import { CamerasService } from './cameras.service';
 import { Notification } from './notification.entity';
 import { Camera } from './camera.entity';
+import { CameraAuthGuard } from './camera-auth.guard';
 
 @Module({
   imports: [MikroOrmModule.forFeature([Camera, Notification])],
   controllers: [CamerasController],
-  providers: [CamerasService],
+  providers: [CameraAuthGuard, CamerasService],
 })
 export class CamerasModule {}

--- a/server/backend/src/cameras/cameras.service.spec.ts
+++ b/server/backend/src/cameras/cameras.service.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@mikro-orm/nestjs';
 import { CamerasService } from './cameras.service';
 import { Notification } from './notification.entity';
 import { NotFoundError } from '../errors.types';
+import { Camera } from './camera.entity';
 
 const notAUUID = 'junk';
 const validCamID = '4fa660b3-bc2d-4d12-b427-32283ca04a07';
@@ -11,6 +12,9 @@ const invalidCamID = 'c5fde899-ac02-465a-ae8b-7e082f1789c8';
 describe('CamerasService', () => {
   let camerasService: CamerasService;
   let mockedNotificationRepository;
+  const mockedCameraRepository = {
+    findOne: jest.fn(),
+  };
 
   beforeEach(async () => {
     mockedNotificationRepository = {
@@ -19,6 +23,7 @@ describe('CamerasService', () => {
         return;
       },
     };
+    mockedCameraRepository.findOne.mockClear();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -26,6 +31,10 @@ describe('CamerasService', () => {
         {
           provide: getRepositoryToken(Notification),
           useValue: mockedNotificationRepository,
+        },
+        {
+          provide: getRepositoryToken(Camera),
+          useValue: mockedCameraRepository,
         },
       ],
     }).compile();
@@ -72,6 +81,21 @@ describe('CamerasService', () => {
       expect(() => {
         camerasService.getNotifications(invalidCamID);
       }).toThrow(NotFoundError);
+    });
+  });
+
+  describe('getPublicKey', () => {
+    it("should return the camera's public key for valid cameras", () => {
+      const camera = new Camera('bogus', 'my-public-key');
+      mockedCameraRepository.findOne.mockResolvedValueOnce(camera);
+      expect(camerasService.getPublicKey('')).resolves.toBe(camera.token);
+    });
+
+    it('should throw a NotFoundError for invalid camera IDs', () => {
+      mockedCameraRepository.findOne.mockResolvedValueOnce(undefined);
+      expect(camerasService.getPublicKey('')).rejects.toBeInstanceOf(
+        NotFoundError,
+      );
     });
   });
 });

--- a/server/backend/src/cameras/cameras.service.ts
+++ b/server/backend/src/cameras/cameras.service.ts
@@ -2,12 +2,16 @@ import { Injectable } from '@nestjs/common';
 import { EntityRepository } from '@mikro-orm/core';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { Notification } from './notification.entity';
+import { Camera } from './camera.entity';
+import { NotFoundError } from '../errors.types';
 
 @Injectable()
 export class CamerasService {
   constructor(
     @InjectRepository(Notification)
     private notificationRepository: EntityRepository<Notification>,
+    @InjectRepository(Camera)
+    private cameraRepository: EntityRepository<Camera>,
   ) {}
 
   sendNotification(id: string): boolean {
@@ -18,5 +22,17 @@ export class CamerasService {
   getNotifications(id: string): Notification[] {
     /* TODO: verify ID, get the notifications */
     return [];
+  }
+
+  /**
+   * Get a camera's PEM-encoded public key.
+   * @param id
+   */
+  public async getPublicKey(id: string): Promise<string> {
+    const camera = await this.cameraRepository.findOne({ id });
+    if (camera === undefined) {
+      throw new NotFoundError(`No camera with ID "${id}" exists`);
+    }
+    return camera.token;
   }
 }

--- a/server/backend/src/util/bytes.ts
+++ b/server/backend/src/util/bytes.ts
@@ -1,0 +1,3 @@
+export function stringToBytes(s: string): Uint8Array {
+  return Uint8Array.from(s.split('').map((x) => x.charCodeAt(0)));
+}

--- a/server/backend/src/util/index.ts
+++ b/server/backend/src/util/index.ts
@@ -1,1 +1,2 @@
+export * from './bytes';
 export * from './timestamp.type';

--- a/server/backend/test/features/send-notification.feature
+++ b/server/backend/test/features/send-notification.feature
@@ -1,29 +1,28 @@
 Feature: Sending a notification
 
-Scenario: Sending without credentials
-	Given I have no credentials
-  And Camera A has 3 notifications
-	When I try to send a notification for camera A
-	Then I receive an 'Unauthorized' error
-  And Camera A has 3 notifications
+  Scenario: Sending without credentials
+    Given I have no credentials
+    And Camera A has 3 notifications
+    When I try to send a notification for camera A
+    Then I receive an 'Unauthorized' error
+    And Camera A has 3 notifications
 
-Scenario: Sending to an invalid camera ID
-	Given I have camera A's credentials
-  And Camera C is not registered
-  When I try to send a notification using camera C's ID
-  Then I recieve an 'Unauthorized' error
-  And Camera C is not registered
+  Scenario: Sending to an invalid camera ID
+    Given I have camera A's credentials
+    And Camera C is not registered
+    When I try to send a notification using camera C's ID
+    Then I recieve a 'Forbidden' error
 
-Scenario: Attempting to send a notification on behalf of camera B using camera A's credentials
-	Given I have camera A's credentials
-  And Camera B has 2 notifications
-	When I try to send a notification on behalf of camera B
-  Then I recieve an 'Unauthorized' error
-  And Camera B has 2 notifications
+  Scenario: Attempting to send a notification on behalf of camera B using camera A's credentials
+    Given I have camera A's credentials
+    And Camera B has 2 notifications
+    When I try to send a notification on behalf of camera B
+    Then I recieve a 'Forbidden' error
+    And Camera B has 2 notifications
 
-Scenario: Sending a notification with valid credentials
-	Given I have camera A's credentials
-  And Camera A has 1 notification
-	When I try to send a notification on behalf of camera A
-  Then The request succeeded
-  And Camera A has 2 notifications
+  Scenario: Sending a notification with valid credentials
+    Given I have camera A's credentials
+    And Camera A has 1 notification
+    When I try to send a notification on behalf of camera A
+    Then The request succeeded
+    And Camera A has 2 notifications

--- a/server/backend/test/helpers/camera.ts
+++ b/server/backend/test/helpers/camera.ts
@@ -1,0 +1,27 @@
+import { generateKeyPairSync, KeyLike, sign } from 'crypto';
+import { stringToBytes } from '../../src/util';
+import { Camera } from '../../src/cameras/camera.entity';
+
+export function createCameraWithKeyPair(name: string): {
+  camera: Camera;
+  keyPair: ReturnType<typeof generateKeyPairSync>;
+} {
+  const keyPair = generateKeyPairSync('ed25519');
+  const camera = new Camera(
+    name,
+    keyPair.publicKey.export({ format: 'pem', type: 'spki' }).toString(),
+  );
+  return { camera, keyPair };
+}
+
+/**
+ * Returns the auth token for a camera.
+ */
+export function getCameraAuthToken(
+  camera: Camera,
+  privateKey: KeyLike,
+): string {
+  return sign(undefined, stringToBytes(camera.id), privateKey).toString(
+    'base64',
+  );
+}

--- a/server/backend/test/helpers/execution-context.ts
+++ b/server/backend/test/helpers/execution-context.ts
@@ -1,0 +1,37 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { getMockReq } from '@jest-mock/express';
+import { ExecutionContext } from '@nestjs/common';
+import { Request } from 'express';
+
+/**
+ * Create a mock HTTP execution context that will return a request with the given parameters.
+ */
+export function createMockHttpExecutionContext(
+  requestOptions?: Parameters<typeof getMockReq>[0],
+): DeepMocked<ExecutionContext> {
+  // '@jest-mock/express' doesn't provide a default header() implementation,
+  // so we need to do that ourselves if we want to pass headers as a dict
+  if (requestOptions && requestOptions.headers && !requestOptions.header) {
+    const mockHeader = jest.fn() as jest.MockedFunction<Request['header']>;
+    mockHeader.mockImplementation((name) => {
+      const header: string | string[] | undefined =
+        requestOptions.headers[name.toLowerCase()];
+      if (header === undefined) {
+        return undefined;
+      } else if (typeof header === 'string') {
+        return header;
+      } else {
+        return header[0];
+      }
+    });
+    requestOptions.header = mockHeader as jest.Mock;
+  }
+  const mockReq = getMockReq(requestOptions);
+  const mockExecutionContext = createMock<ExecutionContext>();
+  mockExecutionContext.switchToHttp.mockReturnValueOnce({
+    getRequest: <T = any>() => mockReq as unknown as T,
+    getNext: () => undefined,
+    getResponse: () => undefined,
+  });
+  return mockExecutionContext;
+}

--- a/server/backend/test/steps/send-notification.steps.ts
+++ b/server/backend/test/steps/send-notification.steps.ts
@@ -86,9 +86,7 @@ defineFeature(feature, (test) => {
       token = getCameraAuthToken(camera, keyPair.privateKey);
     });
     and('Camera C is not registered', () => {
-      // expect(
-      //   cameraRepository.findOne({ id: cameraCId }),
-      // ).resolves.toBeUndefined();
+      expect(cameraRepository.findOne({ id: cameraCId })).resolves.toBeNull();
     });
     when("I try to send a notification using camera C's ID", async () => {
       sendRes = await request(app.getHttpServer())


### PR DESCRIPTION
# Description
Now cameras are required to present their token when calling camera endpoints (heartbeat, send notification). No more spamming Matt's phone :(

#  Testing
- `npm test` - some tests had to be reworked so MikroORM would play nicely with Jest