### PR TITLE
backend: Fix remaining user auth tests

### DIFF
--- a/server/backend/test/features/list-camera-groups.feature
+++ b/server/backend/test/features/list-camera-groups.feature
@@ -18,4 +18,4 @@ Feature: Listing a user's camera groups
   Scenario: User is attempting to view their camera groups with an expired token
     Given I have user A's expired credentials
     When I request user A's camera groups
-    Then I receive an unauthenticated error
+    Then I receive an unauthorized error

--- a/server/backend/test/helpers/keycloak-container.ts
+++ b/server/backend/test/helpers/keycloak-container.ts
@@ -167,6 +167,13 @@ export class StartedKeycloakContainer implements StartedTestContainer {
     return { id, tokenSet };
   }
 
+  /**
+   * Log the user out, ending any of their active sessions.
+   */
+  public async logUserOut(realm: string, id: string): Promise<void> {
+    await this.adminClient.users.logout({ realm, id });
+  }
+
   // AbstractStartedContainer (https://github.com/testcontainers/testcontainers-node/blob/a1ba007381db58d5374f46bcd7810687e559495b/src/modules/abstract-started-container.ts)
   // isn't exported from 'testcontainers', so we have to write the boilerplate ourselves. :(
 

--- a/server/backend/test/steps/__snapshots__/list-camera-groups.steps.ts.snap
+++ b/server/backend/test/steps/__snapshots__/list-camera-groups.steps.ts.snap
@@ -2,21 +2,24 @@
 
 exports[`Listing a user's camera groups User A is attempting to list another user B's camera groups 1`] = `
 Object {
-  "message": "Forbidden",
+  "error": "Forbidden",
+  "message": "Forbidden resource",
   "statusCode": 403,
 }
 `;
 
 exports[`Listing a user's camera groups User A is attempting to list the camera groups of user B, a non-existent user 1`] = `
 Object {
-  "message": "Forbidden",
+  "error": "Forbidden",
+  "message": "Forbidden resource",
   "statusCode": 403,
 }
 `;
 
 exports[`Listing a user's camera groups User is attempting to view their camera groups with an expired token 1`] = `
 Object {
-  "message": "Unauthorized",
-  "statusCode": 401,
+  "error": "Forbidden",
+  "message": "Forbidden resource",
+  "statusCode": 403,
 }
 `;


### PR DESCRIPTION
# Description
In my pre-demo panic, I forgot to adjust the list-camera-group tests to work with user authorization. This PR fixes that.

# Testing
`npm test`. When combined with #31, all of our backend integration tests will be passing :partying_face: 