### PR TITLE
Fix backend CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
+      - name: Build container dependencies
+        working-directory: ./server/
+        run: docker-compose build keycloak
       - name: Install dependencies
         working-directory: ./server/backend
         run: npm ci

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -57,8 +57,8 @@ services:
   nginx:
     image: nginx:latest
     ports:
-      - "${HTTP_PORT}:80"
-      - "${HTTPS_PORT}:443"
+      - "${HTTP_PORT:-8080}:80"
+      - "${HTTPS_PORT:-8443}:443"
     restart: always
     environment:
       API_URL: "${API_URL}"


### PR DESCRIPTION
The backend integration tests depend on some containers being built before running, so we need to update our workflow.