### PR TITLE
backend: Require Docker Compose v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
           node-version: 16
       - name: Build container dependencies
         working-directory: ./server/
-        run: docker-compose build keycloak
+        run: docker compose build keycloak
       - name: Install dependencies
         working-directory: ./server/backend
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -91,25 +91,28 @@ KEYCLOAK_URL=<keycloakUrl> BACKEND_URL=<backendUrl> CLIENT_ID=<clientId> npx exp
 
 ## Testing the Backend
 
-Running tests for the backend requires installing `node` and `npm`.
-It may work with older versions, but it is confirmed working on NodeJS 16.5.1 LTS.
-Once you have `node` and `npm` installed, navigate to `server/backend` and follow
-the instructions in the README for testing.
+### Prerequisites
+- [Node LTS](https://nodejs.org/en/download/)
+- [Docker](https://docs.docker.com/get-docker/) with Compose v2
+
+Docker Desktop should get you a compatible version of Compose. If you're
+Docker through your package manager, make sure you get Compose v2
+(`docker compose` will show a help message if you have it).
 
 ### Manual integration tests
 
 For full integration tests (like with the mobile app and camera), you can spawn
-a full test stack using [Docker](https://docs.docker.com/get-docker/).
+a full test stack using [Docker Compose](https://docs.docker.com/compose/).
 
 Some useful commands:
 
 - Build the containers for each component
   ```sh
-  $ docker-compose build
+  $ docker compose build
   ```
 - Run the test stack
   ```sh
-  $ docker-compose --env-file dev.env up
+  $ docker compose --env-file dev.env up
   ```
 - List running containers
   ```sh
@@ -119,7 +122,7 @@ Some useful commands:
   ```sh
   $ docker exec -it ${POSTGRES_CONTAINER_NAME} psql -U ${DB_USER} ${DB_NAME}
   ```
-- Clean up the resources created by `docker-compose`
+- Clean up the resources created by Compose:
   ```sh
-  $ docker-compose down
+  $ docker compose down
   ```

--- a/server/backend/README.md
+++ b/server/backend/README.md
@@ -31,7 +31,7 @@ $ npm run start:prod
   ```
 - Build the Keycloak container:
   ```bash
-  $ docker-compose build keycloak
+  $ docker compose build keycloak
   ```
 
 ### Running

--- a/server/backend/test/helpers/test-stack.ts
+++ b/server/backend/test/helpers/test-stack.ts
@@ -65,7 +65,7 @@ export async function buildTestStack(
     .withNetworkAliases('db')
     .start();
 
-  const kcContainer = await new KeycloakContainer('server_keycloak:latest')
+  const kcContainer = await new KeycloakContainer('server-keycloak:latest')
     .withNetworkMode(network.getName())
     .withEnv('SYNC_USERS_DB_HOST', 'db')
     .withEnv('SYNC_USERS_DB_NAME', dbContainer.getDatabase())


### PR DESCRIPTION
# Description
Docker seems to have changed image naming conventions for Compose between v1 and v2 ([source](https://stackoverflow.com/a/69519102)), breaking our backend tests on Compose v2. Rather than throwing compatibility flags everywhere to support my dusty old Docker Compose v1 install, I figured it would be best to require v2.

# Testing
- `npm test` still works after removing old `server_*` containers and rebuilding with `docker compose build`
- The backend workflow still appears to be [successfully failing](https://github.com/tucker-moore/human-detector/actions/runs/3304816739/jobs/5454490816) (no issues related to Compose)