### PR TITLE
Add app lint checks to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,20 @@ jobs:
       - name: Run tests
         working-directory: ./app/human-detector-app
         run: npm test
+
+  app-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install dependencies
+        working-directory: ./app/human-detector-app
+        run: npm ci
+      - name: Run linter
+        working-directory: ./app/human-detector-app
+        run: npm run lint
   
   backend-tests:
     runs-on: ubuntu-latest

--- a/app/human-detector-app/App.tsx
+++ b/app/human-detector-app/App.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import * as AuthSession from 'expo-auth-session';
 import CameraScreen from './screens/CameraScreen';
 import GroupScreen from './screens/GroupScreen';
 import LoginScreen from './screens/LoginScreen';
 import { sendExpoNotifToken } from './src/notifications/notifTokenInit';
 import { getUserFromIDToken } from './src/auth/keyCloakAuth';
+import User from './classes/User';
 
 const Stack = createNativeStackNavigator();
 
@@ -15,7 +16,8 @@ export default function App(): React.ReactElement {
   // Hooks
 
   // Update upon getting a token
-  const [tokenResponse, setTokenResponse] = React.useState(null);
+  const [tokenResponse, setTokenResponse] = React.useState<AuthSession.TokenResponse | null>(null);
+  const [user, setUser] = React.useState<User | null>(null);
 
   // Check if the token is expired
   if (tokenResponse != null) {
@@ -29,7 +31,7 @@ export default function App(): React.ReactElement {
 
   React.useEffect(() => {
     if (isUserSignedIn) {
-      sendExpoNotifToken(user.userID, tokenResponse.accessToken).catch(() =>
+      sendExpoNotifToken(user!.userID, tokenResponse!.accessToken).catch(() =>
         console.error('Error in sending expo token!')
       );
     }
@@ -54,7 +56,7 @@ export default function App(): React.ReactElement {
               },
             }}
           >
-            {(props) => <LoginScreen setTokenResponse={setTokenResponse} />}
+            {() => <LoginScreen onTokenResponse={setTokenResponse} />}
           </Stack.Screen>
         </Stack.Navigator>
       </NavigationContainer>
@@ -64,7 +66,7 @@ export default function App(): React.ReactElement {
   // If logged in, make the user and put them into the app
 
   // Translates IDToken to a user
-  const user = getUserFromIDToken(tokenResponse.idToken);
+  setUser(getUserFromIDToken(tokenResponse!.idToken!));
 
   // If the user is logged in return the stack with all the information
   return (
@@ -104,51 +106,3 @@ export default function App(): React.ReactElement {
     </NavigationContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    // paddingTop: 40,
-    // paddingHorizontal: 20
-  },
-  textInput: {
-    borderWidth: 1,
-    borderColor: '#777',
-    padding: 8,
-  },
-  pads: {
-    padding: 10,
-  },
-  boldHeader: {
-    fontWeight: 'bold',
-    fontSize: 20,
-  },
-  menuItem: {
-    marginTop: 24,
-    marginLeft: 20,
-    marginRight: 20,
-    padding: 30,
-    backgroundColor: '#E0FFFF',
-    fontSize: 24,
-    borderWidth: 2,
-    borderColor: '#D3D3D3',
-  },
-  addButtonItem: {
-    borderColor: '#D3D3D3',
-    backgroundColor: '#DCDCDC',
-  },
-  menuButtonText: {
-    fontSize: 24,
-    marginTop: 10,
-    marginBottom: 10,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  addButtonText: {
-    alignItems: 'center',
-    fontSize: 50,
-    marginTop: 0,
-    marginBottom: 0,
-  },
-});

--- a/app/human-detector-app/__tests__/BackendService.test.ts
+++ b/app/human-detector-app/__tests__/BackendService.test.ts
@@ -1,3 +1,5 @@
+import nock from 'nock';
+import { AxiosError } from 'axios';
 import * as BackendService from '../services/backendService';
 import * as ServerConfig from '../config/ServerConfig';
 import User from '../classes/User';
@@ -5,19 +7,13 @@ import Group from '../classes/Group';
 import Camera from '../classes/Camera';
 import Notification from '../classes/Notification';
 
-/**
- * This file is to take care of tests on methods that will be used
- * to reach our REST API backend endpoints.
- */
-
-const nock = require('nock');
 const exampleAccessToken = 'ExampleAccessToken';
 
 // test putting notification key
 describe(BackendService.sendNotifyTokenAPI, () => {
   it('should return code 200 for successful token sending', async () => {
     const newUser: User = new User('tucker', '987654', true);
-    const scope = nock(ServerConfig.apiLink)
+    nock(ServerConfig.apiLink)
       .put(ServerConfig.getSendNotifKeyUrlExtension(newUser.userID))
       .reply(200, 'success');
 
@@ -29,9 +25,8 @@ describe(BackendService.sendNotifyTokenAPI, () => {
   });
 
   it("should return code 401 if user id doesn't exist", async () => {
-    const errorMsg = 'Request failed with status code 401';
     const newUser: User = new User('tucker', '987654', true);
-    const scope = nock(ServerConfig.apiLink)
+    nock(ServerConfig.apiLink)
       .put(ServerConfig.getSendNotifKeyUrlExtension(newUser.userID))
       .reply(401, 'fail');
 
@@ -41,7 +36,7 @@ describe(BackendService.sendNotifyTokenAPI, () => {
         'ExponentPushToken[0000000000]',
         exampleAccessToken
       )
-    ).rejects.toBe(errorMsg);
+    ).rejects.toThrow(AxiosError);
   });
 });
 
@@ -49,11 +44,11 @@ describe(BackendService.getGroupListAPI, () => {
   const newUser: User = new User('bigheadgeorge', '0', true);
 
   it('should return null if there is an error', async () => {
-    const scope = nock(ServerConfig.apiLink)
+    nock(ServerConfig.apiLink)
       .get(ServerConfig.getGroupsListUrlExtension(newUser.userID))
       .reply(401, 'error');
 
-    const result = await BackendService.getGroupListAPI(newUser.userID);
+    const result = await BackendService.getGroupListAPI(newUser.userID, exampleAccessToken);
 
     expect(result).toBe(null);
   });
@@ -71,7 +66,7 @@ describe(BackendService.getGroupListAPI, () => {
     groups.push(groupObj);
     groups.push(groupObj2);
 
-    const scope = nock(ServerConfig.apiLink)
+    nock(ServerConfig.apiLink)
       .get(ServerConfig.getGroupsListUrlExtension(newUser.userID))
       .reply(200, JSON.stringify(groups));
 
@@ -85,7 +80,7 @@ describe(BackendService.getNotificationHistoryAPI, () => {
   const newUser: User = new User('bigheadgeorge', '1234565', true);
 
   it('should return null if there is an error', async () => {
-    const scope = nock(ServerConfig.apiLink)
+    nock(ServerConfig.apiLink)
       .get(ServerConfig.getNotificationHistoryUrlExtension(newUser.userID))
       .reply(401, 'error');
 
@@ -105,7 +100,7 @@ describe(BackendService.getNotificationHistoryAPI, () => {
 
     const notifHistory: Notification[] = [notif1, notif2];
 
-    const scope = nock(ServerConfig.apiLink)
+    nock(ServerConfig.apiLink)
       .get(ServerConfig.getNotificationHistoryUrlExtension(newUser.userID))
       .reply(200, JSON.stringify(notifHistory));
 

--- a/app/human-detector-app/__tests__/Camera.test.ts
+++ b/app/human-detector-app/__tests__/Camera.test.ts
@@ -1,72 +1,72 @@
-import * as React from 'react';
-import renderer from 'react-test-renderer';
-import { Alert, Button } from 'react-native';
-import Camera, { searchForCameras,  initializeCamera, deleteCamera, addCameraToGroup, removeCameraFromGroup } from '../classes/Camera';
+import nock from 'nock';
+import Camera, { deleteCamera, addCameraToGroup } from '../classes/Camera';
 import Group from '../classes/Group';
 import { apiLink, getUsersCamerasUrlExtension } from '../config/ServerConfig';
-
-const nock = require('nock')
 
 // renameCamera test values
 // Critical values: Empty name as input, name over character limit as input, invalid character values.
 it('renameCamera() Test 1: return same class with unchanged name', () => {
-    // character limit 30
-    const cameraObj: Camera = new Camera('0', "Camera 1", "ID");
-    expect(cameraObj.renameCamera('')).toBe(cameraObj);
-})
+  // character limit 30
+  const cameraObj: Camera = new Camera('0', 'Camera 1', 'ID');
+  expect(cameraObj.renameCamera('')).toBe(cameraObj);
+});
 
 it('renameCamera() Test 2: return camera with unchanged name (empty input)', () => {
-    // character limit 30
-    const cameraObj: Camera = new Camera('0', "Camera 1", "ID");
-    expect(cameraObj.renameCamera('Test camera name that will be over the limit').cameraName).toBe(cameraObj.cameraName);
-})
+  // character limit 30
+  const cameraObj: Camera = new Camera('0', 'Camera 1', 'ID');
+  expect(cameraObj.renameCamera('Test camera name that will be over the limit').cameraName).toBe(
+    cameraObj.cameraName
+  );
+});
 
 it('renameCamera() Test 3: return camera with unchanged name (over the character limit input)', () => {
-    // character limit 30
-    const cameraObj: Camera = new Camera('0', "Camera 1", "ID");
-    expect(cameraObj.renameCamera('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa').cameraName).toBe(cameraObj.cameraName);
-})
+  // character limit 30
+  const cameraObj: Camera = new Camera('0', 'Camera 1', 'ID');
+  expect(cameraObj.renameCamera('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa').cameraName).toBe(
+    cameraObj.cameraName
+  );
+});
 
 it('renameCamera() Test 4: return camera with changed name', () => {
-    // character limit 30
-    const cameraObj: Camera = new Camera('0', "Camera 1", "ID");
-    const newName: string = 'Living room';
-    expect(cameraObj.renameCamera(newName).cameraName).toBe(newName);
-})
+  // character limit 30
+  const cameraObj: Camera = new Camera('0', 'Camera 1', 'ID');
+  const newName: string = 'Living room';
+  expect(cameraObj.renameCamera(newName).cameraName).toBe(newName);
+});
 
 it('renameCamera() Test 5: return camera with changed name', () => {
-    // character limit 30
-    const cameraObj: Camera = new Camera('0', "Camera 1", "ID");
-    const newName: string = 'Theater room';
-    expect(cameraObj.renameCamera(newName).cameraName).toBe(newName);
-})
+  // character limit 30
+  const cameraObj: Camera = new Camera('0', 'Camera 1', 'ID');
+  const newName: string = 'Theater room';
+  expect(cameraObj.renameCamera(newName).cameraName).toBe(newName);
+});
 
 it('renameCamera() Test 6: return camera with changed name at exact character limit', () => {
-    // character limit 30
-    const cameraObj: Camera = new Camera('0', "Camera 1", "ID");
-    const newName: string = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-    expect(cameraObj.renameCamera(newName).cameraName).toBe(newName);
-})
+  // character limit 30
+  const cameraObj: Camera = new Camera('0', 'Camera 1', 'ID');
+  const newName: string = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  expect(cameraObj.renameCamera(newName).cameraName).toBe(newName);
+});
 
 it('renameCamera() Test 7: return camera with changed name at 1 character', () => {
-    // character limit 30
-    const cameraObj: Camera = new Camera('0', "Camera 1", "ID");
-    const newName: string = 'a';
-    expect(cameraObj.renameCamera(newName).cameraName).toBe(newName);
-})
+  // character limit 30
+  const cameraObj: Camera = new Camera('0', 'Camera 1', 'ID');
+  const newName: string = 'a';
+  expect(cameraObj.renameCamera(newName).cameraName).toBe(newName);
+});
 it('renameCamera() Test 8: return camera with unchanged name (invalid character)', () => {
-        // character limit 30
-    const cameraObj: Camera = new Camera('0', "Camera 1", "ID");
-    const newName: string = '😮‍💨';
-    expect(cameraObj.renameCamera(newName).cameraName).toBe(newName);
-})
+  // character limit 30
+  const cameraObj: Camera = new Camera('0', 'Camera 1', 'ID');
+  const newName: string = '😮‍💨';
+  expect(cameraObj.renameCamera(newName).cameraName).toBe(newName);
+});
 
 it('renameCamera() Test 9: return camera with unchanged name (invalid character)', () => {
-    // character limit 30
-    const cameraObj: Camera = new Camera('0', "Camera 1", "ID");
-    const newName: string = 'dfsfss😮‍💨dawdawd';
-    expect(cameraObj.renameCamera(newName).cameraName).toBe(newName);
-})
+  // character limit 30
+  const cameraObj: Camera = new Camera('0', 'Camera 1', 'ID');
+  const newName: string = 'dfsfss😮‍💨dawdawd';
+  expect(cameraObj.renameCamera(newName).cameraName).toBe(newName);
+});
 
 // searchForCameras()
 // Critical values: there are cameras searching, no cameras searching, 1 camera searching
@@ -74,79 +74,74 @@ it('renameCamera() Test 9: return camera with unchanged name (invalid character)
 // isCameraOnline()
 // Critical values: camera is online, camera is offline, camera doesn't exist
 it('isCameraOnline() Test 1: camera is online', () => {
-    const cam: Camera = new Camera('0', 'name', 'ID2')
+  const cam: Camera = new Camera('0', 'name', 'ID2');
 
-    const scope = nock(apiLink)
-        .get(getUsersCamerasUrlExtension(cam.userId))
-        .reply(200, 'false')
+  nock(apiLink).get(getUsersCamerasUrlExtension(cam.userId)).reply(200, 'false');
 
-    expect(cam.isCameraOnline()).toBe(true)
-})
+  expect(cam.isCameraOnline()).toBe(true);
+});
 
 it('isCameraOnline() Test 2: camera is offline', () => {
-    const cam: Camera = new Camera('0', 'name', 'ID2')
+  const cam: Camera = new Camera('0', 'name', 'ID2');
 
-    const scope = nock(apiLink)
-        .get(getUsersCamerasUrlExtension(cam.userId))
-        .reply(200, 'true')
+  nock(apiLink).get(getUsersCamerasUrlExtension(cam.userId)).reply(200, 'true');
 
-    expect(cam.isCameraOnline()).toBe(false)
-})
+  expect(cam.isCameraOnline()).toBe(false);
+});
 
 // initializeCamera()
 // Critical values: camera already initialized in the server
 
-
 // deleteCamera()
 // Critical values: camera doesnt exist
 
-it('deleteCamera() Test 1: Don\'t delete camera, doesn\'t exist', () => {
-    const cameraArr: Camera[] = new Array(5);
-    cameraArr[0] = new Camera('0', 'name', 'ID1')
-    cameraArr[1] = new Camera('0', 'name', 'ID2')
-    cameraArr[2] = new Camera('0', 'name', 'ID3')
-    expect(deleteCamera(cameraArr, 'DeletedID')).toBe(cameraArr)
-})
+it("deleteCamera() Test 1: Don't delete camera, doesn't exist", () => {
+  const cameraArr: Camera[] = new Array(5);
+  cameraArr[0] = new Camera('0', 'name', 'ID1');
+  cameraArr[1] = new Camera('0', 'name', 'ID2');
+  cameraArr[2] = new Camera('0', 'name', 'ID3');
+  expect(deleteCamera(cameraArr, 'DeletedID')).toBe(cameraArr);
+});
 
 it('deleteCamera Test 2: Delete camera from Camera List', () => {
-    const cameraArr: Camera[] = new Array(5);
-    cameraArr[0] = new Camera('0', 'name', 'ID1')
-    cameraArr[1] = new Camera('0', 'delete this cam', 'DeletedID')
-    cameraArr[2] = new Camera('0', 'name', 'ID2')
-    expect(deleteCamera(cameraArr, 'DeletedID')).toBe(cameraArr)
-})
+  const cameraArr: Camera[] = new Array(5);
+  cameraArr[0] = new Camera('0', 'name', 'ID1');
+  cameraArr[1] = new Camera('0', 'delete this cam', 'DeletedID');
+  cameraArr[2] = new Camera('0', 'name', 'ID2');
+  expect(deleteCamera(cameraArr, 'DeletedID')).toBe(cameraArr);
+});
 
 it('deleteCamera Test 3: Delete camera from Camera List', () => {
-    const cameraArr: Camera[] = new Array(5);
-    cameraArr[0] = new Camera('0', 'name', 'ID1')
-    cameraArr[1] = new Camera('0', 'name', 'ID2')
-    cameraArr[2] = new Camera('0', 'delete this cam', 'DeletedID')
-    expect(deleteCamera(cameraArr, 'DeletedID')).toBe(cameraArr)
-})
+  const cameraArr: Camera[] = new Array(5);
+  cameraArr[0] = new Camera('0', 'name', 'ID1');
+  cameraArr[1] = new Camera('0', 'name', 'ID2');
+  cameraArr[2] = new Camera('0', 'delete this cam', 'DeletedID');
+  expect(deleteCamera(cameraArr, 'DeletedID')).toBe(cameraArr);
+});
 
 it('deleteCamera Test 4: Delete camera from Camera List', () => {
-    const cameraArr: Camera[] = new Array(5);
-    cameraArr[0] = new Camera('0', 'delete this cam', 'DeletedID')
-    cameraArr[1] = new Camera('0', 'name', 'ID1')
-    cameraArr[2] = new Camera('0', 'name', 'ID2')
-    expect(deleteCamera(cameraArr, 'DeletedID')).toBe(cameraArr)
-})
+  const cameraArr: Camera[] = new Array(5);
+  cameraArr[0] = new Camera('0', 'delete this cam', 'DeletedID');
+  cameraArr[1] = new Camera('0', 'name', 'ID1');
+  cameraArr[2] = new Camera('0', 'name', 'ID2');
+  expect(deleteCamera(cameraArr, 'DeletedID')).toBe(cameraArr);
+});
 
 // addCameraToGroup()
 // Critical values: Group has max number of cameras, adding to empty group, camera is already assigned a group.
 
-it('addCameraToGroup() Test 1: Group is full, don\'t update group list', () => {
-    const group: Group = new Group('testname', 'testID')
-    const cam: Camera = new Camera('0', 'name', 'ID')
-    addCameraToGroup(new Camera('0', 'name', 'ID2'), group)
-    addCameraToGroup(new Camera('0', 'name', 'ID3'), group)
-    addCameraToGroup(new Camera('0', 'name', 'ID4'), group)
-    // max limit
-    expect(addCameraToGroup(cam, group)).toBe(group)
-})
+it("addCameraToGroup() Test 1: Group is full, don't update group list", () => {
+  const group: Group = new Group('testname', 'testID');
+  const cam: Camera = new Camera('0', 'name', 'ID');
+  addCameraToGroup(new Camera('0', 'name', 'ID2'), group);
+  addCameraToGroup(new Camera('0', 'name', 'ID3'), group);
+  addCameraToGroup(new Camera('0', 'name', 'ID4'), group);
+  // max limit
+  expect(addCameraToGroup(cam, group)).toBe(group);
+});
 
 it('addCameraToGroup() Test 2: Adding to empty group', () => {
-    const group = new Group('name', 'ID')
-    const cam = new Camera('0', 'name', 'ID')
-    expect(addCameraToGroup(cam, group)).toBe(group)
-})
+  const group = new Group('name', 'ID');
+  const cam = new Camera('0', 'name', 'ID');
+  expect(addCameraToGroup(cam, group)).toBe(group);
+});

--- a/app/human-detector-app/__tests__/Group.test.ts
+++ b/app/human-detector-app/__tests__/Group.test.ts
@@ -1,6 +1,3 @@
-import * as React from 'react';
-import renderer from 'react-test-renderer';
-import { Alert, Button } from 'react-native';
 import Group, { renameGroup, addToGroup } from '../classes/Group';
 import Camera from '../classes/Camera';
 
@@ -24,7 +21,7 @@ it('renameGroup() Test 3: return group with unchanged name (over the character l
   // character limit 30
   const groupObj: Group = new Group('Group 1', 'ID');
   expect(renameGroup('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', groupObj).groupName).toBe(
-    groupObj.groupObj
+    groupObj.groupName
   );
 });
 

--- a/app/human-detector-app/__tests__/User.test.ts
+++ b/app/human-detector-app/__tests__/User.test.ts
@@ -1,7 +1,4 @@
-import * as React from 'react';
-import renderer from 'react-test-renderer';
-import User, { authenticateLogin, loginUser, getUserNotifPerm, isSnoozeOn } from '../classes/User';
-import { apiLink, loginUrlExtension } from '../config/ServerConfig';
+import User, { isSnoozeOn } from '../classes/User';
 
 // isSnoozeOn()
 // critical values: snooze on, snooze off

--- a/app/human-detector-app/__tests__/__features__/__feature-tests__/PushNotification.steps.ts
+++ b/app/human-detector-app/__tests__/__features__/__feature-tests__/PushNotification.steps.ts
@@ -1,8 +1,5 @@
 import { loadFeature, defineFeature } from 'jest-cucumber';
 import User, { getUserNotifPerm, isSnoozeOn } from '../../../classes/User';
-import { apiLink } from '../../../config/ServerConfig';
-
-const nock = require('nock');
 
 const feature = loadFeature('__tests__/__features__/PushNotification.feature');
 

--- a/app/human-detector-app/__tests__/notifTokenInit.test.ts
+++ b/app/human-detector-app/__tests__/notifTokenInit.test.ts
@@ -1,12 +1,45 @@
 import * as Notifications from 'expo-notifications';
+import { PermissionResponse, PermissionStatus } from 'expo-modules-core';
+import { NotificationPermissionsStatus } from 'expo-notifications';
 import * as helpers from '../src/helpers';
 import * as BackendService from '../services/backendService';
-import * as ServerConfig from '../config/ServerConfig';
-import { sendExpoNotifToken, getExponentPushToken } from '../src/notifications/notifTokenInit';
+import { sendExpoNotifToken } from '../src/notifications/notifTokenInit';
 import User from '../classes/User';
 
 // Allows mocking of expo-notifications
 jest.mock('expo-notifications');
+const mockGetPermissionsAsync = Notifications.getPermissionsAsync as jest.MockedFunction<
+  typeof Notifications.getPermissionsAsync
+>;
+const mockRequestPermissionsAsync = Notifications.requestPermissionsAsync as jest.MockedFunction<
+  typeof Notifications.getPermissionsAsync
+>;
+const mockGetExpoPushTokenAsync = Notifications.getExpoPushTokenAsync as jest.MockedFunction<
+  typeof Notifications.getExpoPushTokenAsync
+>;
+const mockSetNotificationChannelAsync =
+  Notifications.setNotificationChannelAsync as jest.MockedFunction<
+    typeof Notifications.setNotificationChannelAsync
+  >;
+
+jest.mock('../services/backendService');
+const mockSendNotifyToken = BackendService.sendNotifyTokenAPI as jest.MockedFunction<
+  typeof BackendService.sendNotifyTokenAPI
+>;
+
+jest.mock('../src/helpers');
+const mockGetOS = helpers.getOS as jest.MockedFunction<typeof helpers.getOS>;
+const mockIsDevice = helpers.isDevice as jest.MockedFunction<typeof helpers.isDevice>;
+
+// Generate a dummy permission response for testing
+function createPermissionResponse(status: PermissionStatus): PermissionResponse {
+  return {
+    status,
+    expires: 'never',
+    granted: status === PermissionStatus.GRANTED,
+    canAskAgain: true,
+  };
+}
 
 // Example user
 const user: User = new User('fjosejfoesf', '3232323', true);
@@ -15,7 +48,7 @@ const exampleAccessToken = 'ExampleAccessToken';
 
 // Permanent mocks
 beforeEach(() => {
-  helpers.isDevice = jest.fn(() => true);
+  mockIsDevice.mockReturnValue(true);
 });
 
 afterEach(() => {
@@ -23,15 +56,16 @@ afterEach(() => {
 });
 
 describe('sendExpoNotifToken() iOS', () => {
-  helpers.getOS = jest.fn(() => 'iOS');
+  mockGetOS.mockReturnValue('ios');
 
   it('will return void if the function is successful with getting the token ', async () => {
     // Success mocks
-    Notifications.getPermissionsAsync.mockResolvedValue({ status: 'granted' });
-    Notifications.getExpoPushTokenAsync.mockResolvedValue({
+    mockGetPermissionsAsync.mockResolvedValue(createPermissionResponse(PermissionStatus.GRANTED));
+    mockGetExpoPushTokenAsync.mockResolvedValue({
+      type: 'expo',
       data: 'ExponentPushToken[000000000000]',
     });
-    BackendService.sendNotifyTokenAPI = jest.fn(() => Promise.resolve());
+    mockSendNotifyToken.mockResolvedValueOnce();
 
     await sendExpoNotifToken(user.userID, exampleAccessToken);
     expect(helpers.isDevice).toHaveBeenCalledTimes(1);
@@ -48,12 +82,17 @@ describe('sendExpoNotifToken() iOS', () => {
 
   it('will return void if successful and user just turns on notifications', async () => {
     // Success mocks
-    Notifications.getPermissionsAsync.mockResolvedValue({ status: 'undetermined' });
-    Notifications.requestPermissionsAsync.mockResolvedValue({ status: 'granted' });
-    Notifications.getExpoPushTokenAsync.mockResolvedValue({
+    mockGetPermissionsAsync.mockResolvedValue(
+      createPermissionResponse(PermissionStatus.UNDETERMINED)
+    );
+    mockRequestPermissionsAsync.mockResolvedValue(
+      createPermissionResponse(PermissionStatus.GRANTED)
+    );
+    mockGetExpoPushTokenAsync.mockResolvedValue({
+      type: 'expo',
       data: 'ExponentPushToken[000000000000]',
     });
-    BackendService.sendNotifyTokenAPI = jest.fn(() => Promise.resolve());
+    mockSendNotifyToken.mockResolvedValueOnce();
 
     await sendExpoNotifToken(user.userID, exampleAccessToken);
     expect(helpers.isDevice).toHaveBeenCalledTimes(1);
@@ -65,8 +104,12 @@ describe('sendExpoNotifToken() iOS', () => {
 
   it('will return a reject if user just turns off notifications', async () => {
     // Success mocks
-    Notifications.getPermissionsAsync.mockResolvedValue({ status: 'undetermined' });
-    Notifications.requestPermissionsAsync.mockResolvedValue({ status: 'denied' });
+    mockGetPermissionsAsync.mockResolvedValue(
+      createPermissionResponse(PermissionStatus.UNDETERMINED)
+    );
+    mockRequestPermissionsAsync.mockResolvedValue({
+      status: PermissionStatus.DENIED,
+    } as NotificationPermissionsStatus);
 
     const errorMsg = 'Failed to get push token for push notification!';
     await expect(sendExpoNotifToken(user.userID, exampleAccessToken)).rejects.toStrictEqual(
@@ -75,9 +118,12 @@ describe('sendExpoNotifToken() iOS', () => {
   });
 
   it('will return a reject if notifications are off', async () => {
-    Notifications.getPermissionsAsync.mockResolvedValue({ status: 'denied' }); // User turned off notifications
-    Notifications.requestPermissionsAsync.mockResolvedValue({ status: 'denied' }); // User presses no to notifiations
-    Notifications.getExpoPushTokenAsync.mockResolvedValue({
+    mockGetPermissionsAsync.mockResolvedValue(createPermissionResponse(PermissionStatus.DENIED)); // User turned off notifications
+    mockRequestPermissionsAsync.mockResolvedValue(
+      createPermissionResponse(PermissionStatus.DENIED)
+    ); // User presses no to notifiations
+    mockGetExpoPushTokenAsync.mockResolvedValue({
+      type: 'expo',
       data: 'ExponentPushToken[000000000000]',
     });
 
@@ -88,10 +134,8 @@ describe('sendExpoNotifToken() iOS', () => {
   });
 
   it('will return a reject with error message error in sending to server', async () => {
-    Notifications.getPermissionsAsync.mockResolvedValue({ status: 'granted' });
-    BackendService.sendNotifyTokenAPI = jest.fn(() =>
-      Promise.reject(new Error('Placeholder Error'))
-    ); // Sending to server error
+    mockGetPermissionsAsync.mockResolvedValue(createPermissionResponse(PermissionStatus.GRANTED));
+    mockSendNotifyToken.mockRejectedValueOnce(new Error('Placeholder Error')); // Sending to server error
 
     const errorMsg = 'Placeholder Error';
     await expect(sendExpoNotifToken(user.userID, exampleAccessToken)).rejects.toStrictEqual(
@@ -100,10 +144,8 @@ describe('sendExpoNotifToken() iOS', () => {
   });
 
   it('will return a reject if there is an error with getting the ExpoPushToken from the user', async () => {
-    Notifications.getPermissionsAsync.mockResolvedValue({ status: 'granted' });
-    Notifications.getExpoPushTokenAsync = jest.fn(() =>
-      Promise.reject(new Error('Placeholder Error for Test 4'))
-    ); // Getting from the user error
+    mockGetPermissionsAsync.mockResolvedValue(createPermissionResponse(PermissionStatus.GRANTED));
+    mockGetExpoPushTokenAsync.mockRejectedValueOnce(new Error('Placeholder Error for Test 4')); // Getting from the user error
 
     const errorMsg = 'Placeholder Error for Test 4';
     await expect(sendExpoNotifToken(user.userID, exampleAccessToken)).rejects.toStrictEqual(
@@ -113,15 +155,16 @@ describe('sendExpoNotifToken() iOS', () => {
 });
 
 describe('sendExpoNotifToken() android', () => {
-  helpers.getOS = jest.fn(() => 'android');
+  mockGetOS.mockReturnValue('android');
   it('will return void if the function is successful with getting the token ', async () => {
     // Success mocks
-    Notifications.getPermissionsAsync.mockResolvedValue({ status: 'granted' });
-    Notifications.setNotificationChannelAsync = jest.fn(() => Promise.resolve());
-    Notifications.getExpoPushTokenAsync.mockResolvedValue({
+    mockGetPermissionsAsync.mockResolvedValue(createPermissionResponse(PermissionStatus.GRANTED));
+    mockSetNotificationChannelAsync.mockResolvedValueOnce(null);
+    mockGetExpoPushTokenAsync.mockResolvedValue({
+      type: 'expo',
       data: 'ExponentPushToken[000000000000]',
     });
-    BackendService.sendNotifyTokenAPI = jest.fn(() => Promise.resolve());
+    mockSendNotifyToken.mockResolvedValueOnce();
 
     await sendExpoNotifToken(user.userID, exampleAccessToken);
     expect(helpers.isDevice).toHaveBeenCalledTimes(1);

--- a/app/human-detector-app/classes/Camera.tsx
+++ b/app/human-detector-app/classes/Camera.tsx
@@ -1,3 +1,7 @@
+// FIXME: re-evaluate methods and stuff
+/* eslint-disable class-methods-use-this */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// eslint-disable-next-line import/no-cycle
 import Group from './Group';
 
 export default class Camera {
@@ -20,12 +24,12 @@ export default class Camera {
   }
 
   renameCamera(name: string): Camera {
-    //P1
+    // P1
     return new Camera('0', 'name', 'ID');
   }
 
   isCameraOnline(): boolean {
-    //P0
+    // P0
     return true;
   }
 }

--- a/app/human-detector-app/classes/Group.tsx
+++ b/app/human-detector-app/classes/Group.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
-import { View } from 'react-native';
-import { StatusBar } from 'expo-status-bar';
+// FIXME: figure it out :(
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// eslint-disable-next-line import/no-cycle
 import Camera from './Camera';
 
 export default class Group {

--- a/app/human-detector-app/classes/User.tsx
+++ b/app/human-detector-app/classes/User.tsx
@@ -1,5 +1,5 @@
-import * as Notifications from 'expo-notifications';
-import * as Device from 'expo-device';
+// FIXME: re-evaluate methods and remove these
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 export default class User {
   username: string;

--- a/app/human-detector-app/components/CameraSettingsButton.tsx
+++ b/app/human-detector-app/components/CameraSettingsButton.tsx
@@ -1,21 +1,6 @@
 import * as React from 'react';
-import { Button, Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, TouchableOpacity } from 'react-native';
 import { AntDesign } from '@expo/vector-icons';
-import Camera from '../classes/Camera';
-
-export default function CameraSettingsButton(props: { cameraId: string }): React.ReactElement {
-  return (
-    <TouchableOpacity
-      style={styles.menuItemSettingsButton}
-      onPress={() => {
-        // This will do something in the future for now. This is just a placeholder print statement
-        console.log(props.cameraId);
-      }}
-    >
-      <AntDesign name="setting" size={24} color="black" />
-    </TouchableOpacity>
-  );
-}
 
 const styles = StyleSheet.create({
   menuItemSettingsButton: {
@@ -23,3 +8,18 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
+
+export default function CameraSettingsButton(props: { cameraId: string }): React.ReactElement {
+  const { cameraId } = props;
+  return (
+    <TouchableOpacity
+      style={styles.menuItemSettingsButton}
+      onPress={() => {
+        // This will do something in the future for now. This is just a placeholder print statement
+        console.log(cameraId);
+      }}
+    >
+      <AntDesign name="setting" size={24} color="black" />
+    </TouchableOpacity>
+  );
+}

--- a/app/human-detector-app/package-lock.json
+++ b/app/human-detector-app/package-lock.json
@@ -24,6 +24,7 @@
         "expo-device": "~4.2.0",
         "expo-font": "~10.1.0",
         "expo-linking": "~3.1.0",
+        "expo-modules-core": "^0.11.8",
         "expo-notifications": "~0.15.4",
         "expo-random": "~12.2.0",
         "expo-splash-screen": "~0.15.1",
@@ -13265,9 +13266,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-0.9.2.tgz",
-      "integrity": "sha512-p/C0GJxFIIDGwmrWi70Q0ggfsgeUFS25ZkkBgoaHT7MVgiMjlKA/DCC3D6ZUkHl/JlzUm0aTftIGS8LWXsnZBw==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-0.11.8.tgz",
+      "integrity": "sha512-goC2ghZFVaV6nXEbk+kz9oKnQmqW8fHVUCSPxC0QXhV0ay1dA9Ki6qqMPagkBJUPAz89NsNqW3bYR6DFXq7lvA==",
       "dependencies": {
         "compare-versions": "^3.4.0",
         "invariant": "^2.2.4"
@@ -13688,6 +13689,15 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo/node_modules/expo-modules-core": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-0.9.2.tgz",
+      "integrity": "sha512-p/C0GJxFIIDGwmrWi70Q0ggfsgeUFS25ZkkBgoaHT7MVgiMjlKA/DCC3D6ZUkHl/JlzUm0aTftIGS8LWXsnZBw==",
+      "dependencies": {
+        "compare-versions": "^3.4.0",
+        "invariant": "^2.2.4"
       }
     },
     "node_modules/expo/node_modules/node-fetch": {
@@ -40197,6 +40207,15 @@
         "uuid": "^3.4.0"
       },
       "dependencies": {
+        "expo-modules-core": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-0.9.2.tgz",
+          "integrity": "sha512-p/C0GJxFIIDGwmrWi70Q0ggfsgeUFS25ZkkBgoaHT7MVgiMjlKA/DCC3D6ZUkHl/JlzUm0aTftIGS8LWXsnZBw==",
+          "requires": {
+            "compare-versions": "^3.4.0",
+            "invariant": "^2.2.4"
+          }
+        },
         "node-fetch": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -40833,9 +40852,9 @@
       }
     },
     "expo-modules-core": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-0.9.2.tgz",
-      "integrity": "sha512-p/C0GJxFIIDGwmrWi70Q0ggfsgeUFS25ZkkBgoaHT7MVgiMjlKA/DCC3D6ZUkHl/JlzUm0aTftIGS8LWXsnZBw==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-0.11.8.tgz",
+      "integrity": "sha512-goC2ghZFVaV6nXEbk+kz9oKnQmqW8fHVUCSPxC0QXhV0ay1dA9Ki6qqMPagkBJUPAz89NsNqW3bYR6DFXq7lvA==",
       "requires": {
         "compare-versions": "^3.4.0",
         "invariant": "^2.2.4"

--- a/app/human-detector-app/package.json
+++ b/app/human-detector-app/package.json
@@ -38,6 +38,7 @@
     "expo-device": "~4.2.0",
     "expo-font": "~10.1.0",
     "expo-linking": "~3.1.0",
+    "expo-modules-core": "^0.11.8",
     "expo-notifications": "~0.15.4",
     "expo-random": "~12.2.0",
     "expo-splash-screen": "~0.15.1",

--- a/app/human-detector-app/screens/CameraScreen.tsx
+++ b/app/human-detector-app/screens/CameraScreen.tsx
@@ -1,10 +1,56 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { Platform, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import * as Notifications from 'expo-notifications';
-import * as Device from 'expo-device';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import CameraSettingsButton from '../components/CameraSettingsButton';
 import Camera from '../classes/Camera';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    // paddingTop: 40,
+    // paddingHorizontal: 20
+  },
+  textInput: {
+    borderWidth: 1,
+    borderColor: '#777',
+    padding: 8,
+  },
+  pads: {
+    padding: 10,
+  },
+  boldHeader: {
+    fontWeight: 'bold',
+    fontSize: 20,
+  },
+  menuItem: {
+    marginTop: 24,
+    marginLeft: 20,
+    marginRight: 20,
+    padding: 30,
+    backgroundColor: '#E0FFFF',
+    fontSize: 24,
+    borderWidth: 2,
+    borderColor: '#D3D3D3',
+  },
+  addButtonItem: {
+    borderColor: '#D3D3D3',
+    backgroundColor: '#DCDCDC',
+  },
+  menuButtonText: {
+    fontSize: 24,
+    marginTop: 10,
+    marginBottom: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  addButtonText: {
+    alignItems: 'center',
+    fontSize: 50,
+    marginTop: 0,
+    marginBottom: 0,
+  },
+});
 
 export default function CameraScreen(): React.ReactElement {
   const cameraOne: Camera = new Camera('123', "AAAAA's Camera", '99');
@@ -60,50 +106,3 @@ export function isCameraOnline(): boolean {
   return true;
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    // paddingTop: 40,
-    // paddingHorizontal: 20
-  },
-  textInput: {
-    borderWidth: 1,
-    borderColor: '#777',
-    padding: 8,
-  },
-  pads: {
-    padding: 10,
-  },
-  boldHeader: {
-    fontWeight: 'bold',
-    fontSize: 20,
-  },
-  menuItem: {
-    marginTop: 24,
-    marginLeft: 20,
-    marginRight: 20,
-    padding: 30,
-    backgroundColor: '#E0FFFF',
-    fontSize: 24,
-    borderWidth: 2,
-    borderColor: '#D3D3D3',
-  },
-  addButtonItem: {
-    borderColor: '#D3D3D3',
-    backgroundColor: '#DCDCDC',
-  },
-  menuButtonText: {
-    fontSize: 24,
-    marginTop: 10,
-    marginBottom: 10,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  addButtonText: {
-    alignItems: 'center',
-    fontSize: 50,
-    marginTop: 0,
-    marginBottom: 0,
-  },
-});

--- a/app/human-detector-app/screens/GroupScreen.tsx
+++ b/app/human-detector-app/screens/GroupScreen.tsx
@@ -1,62 +1,9 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import Camera from '../classes/Camera';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import CameraSettingsButton from '../components/CameraSettingsButton';
 import Group from '../classes/Group';
-
-export default function GroupMenu({ navigation }: Props): React.ReactElement {
-  const groupOne: Group = new Group("AAAAAA's Group", '99');
-  const groupTwo: Group = new Group("BBBBB's Group", '725');
-  const groupThree: Group = new Group("CCCCC's Group", '400');
-
-  const [listOfCameras, setListOfCameras] = useState([groupOne, groupTwo, groupThree]);
-
-  const pressHandler = () => {
-    navigation.navigate('Cameras');
-    console.log(typeof navigation);
-  };
-
-  return (
-    <View style={styles.container}>
-      <ScrollView>
-        {listOfCameras.map((item) => (
-          <View key={item.groupId}>
-            <TouchableOpacity style={styles.menuItem} onPress={pressHandler}>
-              <Text style={styles.menuButtonText}> {item.groupName} </Text>
-              <CameraSettingsButton cameraId={item.groupId} />
-            </TouchableOpacity>
-          </View>
-        ))}
-
-        <View key="add-button">
-          <TouchableOpacity
-            style={[styles.menuItem, styles.addButtonItem]}
-            onPress={() => {
-              const cameraList: Camera[] = [...listOfCameras];
-              // adding camera here test
-              cameraList.push(new Camera('test', 'test', 'test'));
-              setListOfCameras(cameraList);
-            }}
-          >
-            <Text style={styles.addButtonText}> + </Text>
-          </TouchableOpacity>
-        </View>
-      </ScrollView>
-    </View>
-
-    /*
-     * Instead of doing FlatList, I might want to change this to a scrollable view
-     */
-    //   <SafeAreaView style={styles.container}>
-    //     <FlatList
-    //         data={listOfCameras}
-    //         renderItem={renderItem}
-    //     />
-    //   </SafeAreaView>
-    //
-  );
-}
 
 const styles = StyleSheet.create({
   container: {
@@ -105,6 +52,59 @@ const styles = StyleSheet.create({
     marginBottom: 0,
   },
 });
+
+// FIXME: Define the route params object (first param to the 'NativeStackScreenProps' type) in one central file
+//        so each component can use it. The dummy object here is a placeholder to pass typechecking.
+export default function GroupScreen({
+  navigation,
+}: NativeStackScreenProps<{ Group: undefined; Cameras: undefined }, 'Group'>): React.ReactElement {
+  const groupOne: Group = new Group("AAAAAA's Group", '99');
+  const groupTwo: Group = new Group("BBBBB's Group", '725');
+  const groupThree: Group = new Group("CCCCC's Group", '400');
+
+  const [listOfGroups, setListOfGroups] = useState([groupOne, groupTwo, groupThree]);
+
+  const pressHandler = () => {
+    navigation.navigate('Cameras');
+  };
+
+  return (
+    <View style={styles.container}>
+      <ScrollView>
+        {listOfGroups.map((item) => (
+          <View key={item.groupId}>
+            <TouchableOpacity style={styles.menuItem} onPress={pressHandler}>
+              <Text style={styles.menuButtonText}> {item.groupName} </Text>
+              <CameraSettingsButton cameraId={item.groupId} />
+            </TouchableOpacity>
+          </View>
+        ))}
+
+        <View key="add-button">
+          <TouchableOpacity
+            style={[styles.menuItem, styles.addButtonItem]}
+            onPress={() =>
+              setListOfGroups((oldGroups) => [...oldGroups, new Group('test', 'test')])
+            }
+          >
+            <Text style={styles.addButtonText}> + </Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </View>
+
+    /*
+     * Instead of doing FlatList, I might want to change this to a scrollable view
+     */
+    //   <SafeAreaView style={styles.container}>
+    //     <FlatList
+    //         data={listOfCameras}
+    //         renderItem={renderItem}
+    //     />
+    //   </SafeAreaView>
+    //
+  );
+}
 
 export function GroupOnPress() {
   return (

--- a/app/human-detector-app/screens/LoginScreen.tsx
+++ b/app/human-detector-app/screens/LoginScreen.tsx
@@ -1,6 +1,12 @@
+import { TokenResponse } from 'expo-auth-session';
 import * as React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View } from 'react-native';
 import KeyCloakButton from '../components/KeyCloakButton';
+
+interface Props {
+  // Called when the authentication flow completes and we've received a token set
+  onTokenResponse(response: TokenResponse): void;
+}
 
 /**
  * Screen will automatically open to log in to KeyCloak.
@@ -9,19 +15,10 @@ import KeyCloakButton from '../components/KeyCloakButton';
  *
  * @returns LoginScreen component
  */
-export default function LoginScreen({ setTokenResponse }): React.ReactElement {
+export default function LoginScreen({ onTokenResponse }: Props): React.ReactElement {
   return (
     <View>
-      <KeyCloakButton setTokenResponse={setTokenResponse} />
+      <KeyCloakButton onTokenResponse={onTokenResponse} />
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    // paddingTop: 40,
-    // paddingHorizontal: 20
-  },
-});

--- a/app/human-detector-app/screens/NotifScreen.tsx
+++ b/app/human-detector-app/screens/NotifScreen.tsx
@@ -1,7 +1,3 @@
-import * as React from 'react';
-import { StatusBar } from 'expo-status-bar';
-import { View } from 'react-native';
-
 export default function NotifScreen() {}
 
 export function ListNotifs() {}

--- a/app/human-detector-app/screens/SettingsScreen.tsx
+++ b/app/human-detector-app/screens/SettingsScreen.tsx
@@ -1,7 +1,3 @@
-import * as React from 'react';
-import { StatusBar } from 'expo-status-bar';
-import { View } from 'react-native';
-
 export default function SettingsScreen() {}
 
 export function ListSettings() {}

--- a/app/human-detector-app/services/backendService.ts
+++ b/app/human-detector-app/services/backendService.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import { z } from 'zod';
 import Group from '../classes/Group';
 import Notification from '../classes/Notification';
 import * as ServerUrl from '../config/ServerConfig';
@@ -36,7 +35,7 @@ export async function getGroupListAPI(
     const response = await axios.get(apiLinkWithExtension, config);
     return response.data;
   } catch (error) {
-    console.error(`Error in getGroupListAPI status code: ${error.message}`);
+    console.error(`Error in getGroupListAPI status code:`, error);
     return null;
   }
 }
@@ -66,16 +65,17 @@ export async function sendNotifyTokenAPI(
     const apiLinkWithExtension: string =
       ServerUrl.apiLink + ServerUrl.getSendNotifKeyUrlExtension(userIdFromLogin);
 
-    const response = await axios.put(
+    await axios.put(
       apiLinkWithExtension,
       {
         expoToken: expoTokenFromLogin,
       },
       config
     );
+    return undefined;
   } catch (error) {
-    console.error(`Error in sendNotifyAPI status code ${error.message}`);
-    return Promise.reject(error.message);
+    console.error(`Error in sendNotifyAPI status code:`, error);
+    return Promise.reject(error);
   }
   // no error: return void
 }
@@ -104,7 +104,7 @@ export async function getNotificationHistoryAPI(
     const response = await axios.get(apiLinkWithExtension, config);
     return response.data;
   } catch (error) {
-    console.error(`Error in getNotificationHistoryAPI status code: ${error.message}`);
+    console.error(`Error in getNotificationHistoryAPI status code:`, error);
     return null;
   }
 }


### PR DESCRIPTION
# Description
I noticed a few (hundred) linter errors when I started looking at the mobile app, so I cleaned them all up and added a job to enforce linter checks because I'm evil.

# Testing
- `npm run lint` reports 9 warnings and 0 errors. If you run this on `main`, you'll get about 100 errors.
- Tests previously passing with `npm test` still pass