### PR TITLE
Fix infinite rerendering on login

### DIFF
--- a/app/human-detector-app/App.tsx
+++ b/app/human-detector-app/App.tsx
@@ -56,17 +56,20 @@ export default function App(): React.ReactElement {
               },
             }}
           >
-            {() => <LoginScreen onTokenResponse={setTokenResponse} />}
+            {() => (
+              <LoginScreen
+                onTokenResponse={(response) => {
+                  // Translates IDToken to a user
+                  setUser(getUserFromIDToken(response.idToken!));
+                  setTokenResponse(response);
+                }}
+              />
+            )}
           </Stack.Screen>
         </Stack.Navigator>
       </NavigationContainer>
     );
   }
-
-  // If logged in, make the user and put them into the app
-
-  // Translates IDToken to a user
-  setUser(getUserFromIDToken(tokenResponse!.idToken!));
 
   // If the user is logged in return the stack with all the information
   return (


### PR DESCRIPTION
# Description
I'm a little dumb and I missed this during manual testing of #39. Calling `setUser` causes another re-render, which causes another call and so on... so we should only call it in the token response callback.

# Testing
We don't have any automated tests for this kind of stuff, so you'll just have to trust me:tm: that my manual testing was correct this time.