### PR TITLE
[EYE-87] Display notifications when app is foregrounded

### DIFF
--- a/app/human-detector-app/App.tsx
+++ b/app/human-detector-app/App.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import * as Notifications from 'expo-notifications';
 import { BleManager } from 'react-native-ble-plx';
 import CameraScreen from './screens/CameraScreen';
 import GroupScreen from './screens/GroupScreen';
@@ -15,6 +16,14 @@ import { RootStackParamList } from './src/navigation/stackParamList';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 const bleService = new BLEService(new BleManager());
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+  }),
+});
 
 export default function App(): React.ReactElement {
   const [backendService, setBackendService] = React.useState<BackendService | null>(null);


### PR DESCRIPTION
# Description
Notifications weren't being shown during demo, but they work if the app is in the background. This PR fixes the notification handling while the app is in the foreground.

# Testing
Logging in with the test user and sending a notification with [the tool](https://expo.dev/notifications) works both when the app is in the foreground and in the background.