### PR TITLE
[EYE-78] Push notification updates, redirects

### DIFF
--- a/app/human-detector-app/App.tsx
+++ b/app/human-detector-app/App.tsx
@@ -83,7 +83,6 @@ export default function App(): React.ReactElement {
                       console.error('Error fetching or updating push token', error)
                     );
                   setGroups((await backend.getGroupListAPI()) ?? []);
-                  // FIXME: this seems to be capturing the initial value of 'groups', which is just an empty list. :(
                   Notifications.setNotificationHandler({
                     handleNotification: async (pushNotification) => {
                       const ignoreNotificationBehavior: NotificationBehavior = {

--- a/app/human-detector-app/App.tsx
+++ b/app/human-detector-app/App.tsx
@@ -4,6 +4,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import * as Notifications from 'expo-notifications';
 import { BleManager } from 'react-native-ble-plx';
 import { FontAwesome } from '@expo/vector-icons';
+import { NotificationBehavior } from 'expo-notifications';
 import CameraScreen from './screens/CameraScreen';
 import GroupScreen from './screens/GroupScreen';
 import LoginScreen from './screens/LoginScreen';
@@ -20,22 +21,21 @@ import User from './classes/User';
 import Group from './classes/Group';
 import NotifScreen from './screens/NotifScreen';
 import SnapshotScreen from './screens/SnapshotScreen';
+import { zPushNotificationData } from './classes/PushNotificationData';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 const bleService = new BLEService(new BleManager());
-
-Notifications.setNotificationHandler({
-  handleNotification: async () => ({
-    shouldShowAlert: true,
-    shouldPlaySound: true,
-    shouldSetBadge: false,
-  }),
-});
 
 export default function App(): React.ReactElement {
   const [backendService, setBackendService] = React.useState<BackendService | null>(null);
   const [groups, setGroups] = React.useState<Group[]>([]);
  
+
+  // HACK: this ref is only necessary so the Notification handler has an up-to-date reference to 'groups'
+  const groupsRef = React.useRef<Group[]>(groups);
+  React.useEffect(() => {
+    groupsRef.current = groups;
+  }, [groups]);
 
   // If the user isn't logged in
   if (backendService === null) {
@@ -61,6 +61,60 @@ export default function App(): React.ReactElement {
                       console.error('Error fetching or updating push token', error)
                     );
                   setGroups((await backend.getGroupListAPI()) ?? []);
+                  // FIXME: this seems to be capturing the initial value of 'groups', which is just an empty list. :(
+                  Notifications.setNotificationHandler({
+                    handleNotification: async (pushNotification) => {
+                      const ignoreNotificationBehavior: NotificationBehavior = {
+                        shouldShowAlert: false,
+                        shouldPlaySound: false,
+                        shouldSetBadge: false,
+                      };
+
+                      const pushNotificationDataParseResult = zPushNotificationData.safeParse(
+                        pushNotification.request.content.data
+                      );
+                      if (!pushNotificationDataParseResult.success) {
+                        console.error(
+                          'Failed to parse push notification data',
+                          pushNotificationDataParseResult.error
+                        );
+                        return ignoreNotificationBehavior;
+                      }
+                      const pushNotificationData = pushNotificationDataParseResult.data;
+
+                      const group = groupsRef.current.find(
+                        (grp) => grp.groupId === pushNotificationData.groupId
+                      );
+                      const camera = group?.cameras.find(
+                        (cam) => cam.cameraId === pushNotificationData.cameraId
+                      );
+                      if (camera === undefined) {
+                        const notificationId = pushNotificationData.notification.id;
+                        console.log(
+                          `Received notification with ID "${notificationId}", which isn't associated with any known cameras.`
+                        );
+                        return ignoreNotificationBehavior;
+                      }
+
+                      // Don't notify again for a notification that has already been received
+                      if (
+                        camera.notifications.find(
+                          (notification) => notification.id === pushNotificationData.notification.id
+                        )
+                      ) {
+                        console.log('Ignoring notification', { pushNotificationData });
+                        return ignoreNotificationBehavior;
+                      }
+
+                      // FIXME: this doesn't cause a re-render if the notification is received while on the notifications screen
+                      camera.notifications.push(pushNotificationData.notification);
+                      return {
+                        shouldShowAlert: true,
+                        shouldPlaySound: true,
+                        shouldSetBadge: false,
+                      };
+                    },
+                  });
                 }}
               />
             )}
@@ -80,7 +134,7 @@ export default function App(): React.ReactElement {
         <BLEContext.Provider value={bleService}>
           <BackendContext.Provider value={backendService}>
             <Stack.Navigator
-              screenOptions={({navigation}) => ({
+              screenOptions={({ navigation }) => ({
                 headerStyle: {
                   backgroundColor: '#1E90FF',
                 },

--- a/app/human-detector-app/classes/Notification.ts
+++ b/app/human-detector-app/classes/Notification.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 export default class Notification {
   id: string;
 
@@ -11,3 +13,14 @@ export default class Notification {
     this.snapshotId = snapshotId;
   }
 }
+
+export const zNotification = z
+  .object({
+    id: z.string().uuid(),
+    timestamp: z.string(), // FIXME: validate that this is a date
+    snapshotId: z.string().uuid(),
+  })
+  .transform(
+    (zodNotif) => new Notification(zodNotif.id, new Date(zodNotif.timestamp), zodNotif.snapshotId)
+  );
+export type ZNotification = z.infer<typeof zNotification>;

--- a/app/human-detector-app/classes/PushNotificationData.ts
+++ b/app/human-detector-app/classes/PushNotificationData.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import { zNotification } from './Notification';
+
+export const zPushNotificationData = z.object({
+  groupId: z.string().uuid(),
+  cameraId: z.string().uuid(),
+  notification: zNotification,
+});
+export type ZPushNotificationData = z.infer<typeof zPushNotificationData>;

--- a/server/backend/src/cameras/cameras.service.ts
+++ b/server/backend/src/cameras/cameras.service.ts
@@ -55,7 +55,11 @@ export class CamerasService {
       data: {
         groupId: cam.group.id,
         cameraId: cam.id,
-        notificationId: notification.id,
+        notification: {
+          id: notification.id,
+          timestamp: notification.timestamp,
+          snapshotId: notification.snapshot.id,
+        },
       },
     };
     try {

--- a/server/backend/src/cameras/cameras.service.ts
+++ b/server/backend/src/cameras/cameras.service.ts
@@ -36,19 +36,27 @@ export class CamerasService {
   ): Promise<boolean> {
     const cam = await this.cameraRepository.findOne(
       { id: idCam },
-      { populate: ['group.user'] },
+      { populate: ['group.id', 'group.user'] },
     );
 
     if (cam === null) {
       throw new NotFoundError(`Camera with given ID does not exist.`);
     }
 
+    const notification = new Notification(new Snapshot(frame));
+    cam.notifications.add(notification);
+    await this.cameraRepository.flush();
+
     const pushToken = cam.group.user.expoToken;
     const pushNotification: IPushNotification = {
       sound: 'default',
       title: `${cam.name} has detected movement!`,
       body: 'This is a test notification',
-      data: { withSome: 'data' },
+      data: {
+        groupId: cam.group.id,
+        cameraId: cam.id,
+        notificationId: notification.id,
+      },
     };
     try {
       await this.pushNotificationsService.sendPushNotification(
@@ -59,8 +67,6 @@ export class CamerasService {
       console.error('Error sending push notification', error);
     }
 
-    cam.notifications.add(new Notification(new Snapshot(frame)));
-    await this.cameraRepository.flush();
     return true;
   }
 

--- a/server/backend/src/cameras/cameras.service.ts
+++ b/server/backend/src/cameras/cameras.service.ts
@@ -51,7 +51,7 @@ export class CamerasService {
     const pushNotification: IPushNotification = {
       sound: 'default',
       title: `${cam.name} has detected movement!`,
-      body: 'This is a test notification',
+      body: 'Tap for more info',
       data: {
         groupId: cam.group.id,
         cameraId: cam.id,


### PR DESCRIPTION
# Description
This PR synchronizes the app's notification list using received push notifications, as well as redirecting to a notification's associated snapshot upon tapping the notification.

TODOs:
- [x] Add received push notifications to the app's local list of notifications for a camera
- [ ] Re-render notifications screen to reflect these changes
- [x] Redirect to snapshot upon tapping a push notification

# Testing
- [x] Manual testing of synchronization 
  - Use [this](https://pastebin.com/zuDZQESR) data (pw `senioritis`) in the [Push Notification Tool](https://expo.dev/notifications) while logged in as the test user. You should receive a new notification for the `awnaw` camera in `the group`
- [x] Manual synchronization testing using a notification delivered from the backend
- [x] Redirect tests