### PR TITLE
Bluetooth Screen styling.

### DIFF
--- a/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
+++ b/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
@@ -45,8 +45,7 @@ export default function BluetoothScreen({ navigation }: Props): React.ReactEleme
       val *= 0x100;
       val += bytes[i];
     }
-        
-    console.log(val.toString(16))
+
     return `${device.name} - ${val.toString(16)}`;
   }     
 

--- a/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
+++ b/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
-import { View, ScrollView, Button } from 'react-native';
+import { View, ScrollView, Button, Text, TouchableOpacity } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Device } from 'react-native-ble-plx';
+import { enc } from 'crypto-js';
 import { LoadingIcon, LoadingState } from '../../components/LoadingIcon';
 import { BLEParamList } from '../../src/navigation/bleParamList';
 import { BLEContext } from '../../contexts/bleContext';
-import { requestPermissions } from '../../src/ble/helpers';
+import { requestPermissions, base64ToJson } from '../../src/ble/helpers';
+import { styles } from '../../src/styles';
 
 /**
  * This screen will start scanning on the device for bluetooth devices.
@@ -23,6 +25,31 @@ export default function BluetoothScreen({ navigation }: Props): React.ReactEleme
   const [allDevices, setAllDevices] = React.useState<Device[]>([]);
   const bleService = React.useContext(BLEContext);
 
+  function getTitle(device: Device): string {
+    if (device.manufacturerData == null) return "Invalid Device";
+    const base64CryptoWord = enc.Base64.parse(device.manufacturerData);
+    const hexStr = base64CryptoWord.toString(enc.Hex);
+       
+    const bytes = [];
+    for (let i = hexStr.length; i > 0; i -= 2) {
+      bytes.push(parseInt(hexStr.substring(i - 2, i), 16));
+    }
+    
+    if (bytes.length < 2 || 
+        bytes[bytes.length - 1] !== 0xFF || 
+        bytes[bytes.length - 2] !== 0xFF)
+      return "Invalid manufacturer";
+        
+    let val = 0;
+    for (let i = 0; i < bytes.length - 2; i += 1) {
+      val *= 0x100;
+      val += bytes[i];
+    }
+        
+    console.log(val.toString(16))
+    return `${device.name} - ${val.toString(16)}`;
+  }     
+
   useFocusEffect(() => {
     requestPermissions().then((isGranted: boolean) => {
       if (isGranted) {
@@ -38,10 +65,12 @@ export default function BluetoothScreen({ navigation }: Props): React.ReactEleme
   return (
     <View style={{ flex: 1 }}>
       <ScrollView>
-        {allDevices.map((item) => (
-          <View key={item.id}>
-            <Button
-              title={item.id}
+      <Text style={styles.registerCamText}> To register a camera, click on the desired camera in the list below This list will update automatically. </Text>
+        {allDevices
+          .filter((dev) => dev.manufacturerData != null)
+          .map((item) => (
+          <View key={item.manufacturerData}>
+            <TouchableOpacity
               onPress={() => {
                 if (connecting) return;
                 setConnecting(true);
@@ -58,7 +87,9 @@ export default function BluetoothScreen({ navigation }: Props): React.ReactEleme
                     setConnecting(false);
                   });
               }}
-            />
+            >
+              <Text style={styles.registerCamButtonText}> {getTitle(item)} </Text>
+            </TouchableOpacity>
           </View>
         ))}
       </ScrollView>

--- a/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
+++ b/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
@@ -71,6 +71,7 @@ export default function BluetoothScreen({ navigation }: Props): React.ReactEleme
           .map((item) => (
           <View key={item.manufacturerData}>
             <TouchableOpacity
+              style={styles.registerCamButton} 
               onPress={() => {
                 if (connecting) return;
                 setConnecting(true);

--- a/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
+++ b/app/human-detector-app/screens/CameraRegistration/BluetoothScreen.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, ScrollView, Button, Text, TouchableOpacity } from 'react-native';
+import { View, ScrollView, Text, TouchableOpacity } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Device } from 'react-native-ble-plx';
@@ -7,7 +7,7 @@ import { enc } from 'crypto-js';
 import { LoadingIcon, LoadingState } from '../../components/LoadingIcon';
 import { BLEParamList } from '../../src/navigation/bleParamList';
 import { BLEContext } from '../../contexts/bleContext';
-import { requestPermissions, base64ToJson } from '../../src/ble/helpers';
+import { requestPermissions } from '../../src/ble/helpers';
 import { styles } from '../../src/styles';
 
 /**

--- a/app/human-detector-app/screens/LoginScreen.tsx
+++ b/app/human-detector-app/screens/LoginScreen.tsx
@@ -20,7 +20,7 @@ interface Props {
 export default function LoginScreen({ onSuccessfulLogin }: Props): React.ReactElement<Props> {
   return (
     <View style={styles.centerIcon}>
-      <Text style={styles.loginText}> Login to EyeSpy </Text>
+      <Text style={styles.loginText}> Welcome to EyeSpy </Text>
       <Button
         title="Login"
         onPress={() => {

--- a/app/human-detector-app/src/styles.ts
+++ b/app/human-detector-app/src/styles.ts
@@ -77,4 +77,23 @@ export const styles = StyleSheet.create({
     fontWeight: 'bold',
     margin: 20,
   },
+  registerCamText: {
+    fontSize: 20,
+    color: '#696969',
+    marginTop: 8,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  registerCamButton: {
+    margin: 20,
+    marginTop: 0,
+    padding: 14,
+    borderWidth: 2,
+    borderColor: '#525252',
+    backgroundColor: '#C5C5C5',
+  },
+  registerCamButtonText: {
+    fontSize: 20,
+    textAlign: 'center',
+  },
 });

--- a/app/human-detector-app/src/styles.ts
+++ b/app/human-detector-app/src/styles.ts
@@ -81,6 +81,8 @@ export const styles = StyleSheet.create({
     fontSize: 20,
     color: '#696969',
     marginTop: 8,
+    marginRight: 4,
+    marginLeft: 4,
     marginBottom: 8,
     textAlign: 'center',
   },


### PR DESCRIPTION
This PR deals with changing how the styling looks in the `BluetoothScreen` for registering a new camera.

- Added text that tells the user what is supposed to be happening on this screen.
- Then adds X-number of `TouchableOpacities` for how many cameras it detects and a value given by `getTitle(device)`

Includes changes that Avery sent over, so make sure that those changes line up and verify that the changes look just like the image below since an Emulated Android cannot do Bluetooth. It won't look exactly like below, just verify that styling-wise everything matches up.

![stylingBLE](https://user-images.githubusercontent.com/59743258/204679049-d00e73b5-02d0-4d3b-ba3b-0186c9322b28.png)

