### PR TITLE
Prettier notification timestamp formatting

### DIFF
--- a/app/human-detector-app/App.tsx
+++ b/app/human-detector-app/App.tsx
@@ -22,6 +22,10 @@ import Group from './classes/Group';
 import NotifScreen from './screens/NotifScreen';
 import SnapshotScreen from './screens/SnapshotScreen';
 import { zPushNotificationData } from './classes/PushNotificationData';
+// Android uses a stripped down JS engine for React Native apps that doesn't support
+// this API, so we need a polyfill: https://stackoverflow.com/a/70261935
+import 'intl';
+import 'intl/locale-data/jsonp/en';
 
 const navigatorRef = createNavigationContainerRef<RootStackParamList>();
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -30,7 +34,6 @@ const bleService = new BLEService(new BleManager());
 export default function App(): React.ReactElement {
   const [backendService, setBackendService] = React.useState<BackendService | null>(null);
   const [groups, setGroups] = React.useState<Group[]>([]);
- 
 
   // HACK: this ref is only necessary so the Notification handler has an up-to-date reference to 'groups'
   const groupsRef = React.useRef<Group[]>(groups);
@@ -164,15 +167,21 @@ export default function App(): React.ReactElement {
                   fontWeight: 'bold',
                 },
                 // eslint-disable-next-line react/no-unstable-nested-components
-                headerRight: () => <FontAwesome name = "bell" size={28} color="white" onPress={() => {
-                  navigation.navigate('Notifications', { notifications: user.getAllNotifications()});
-                }}/>
+                headerRight: () => (
+                  <FontAwesome
+                    name="bell"
+                    size={28}
+                    color="white"
+                    onPress={() => {
+                      navigation.navigate('Notifications', {
+                        notifications: user.getAllNotifications(),
+                      });
+                    }}
+                  />
+                ),
               })}
             >
-              <Stack.Screen 
-                name="Groups" 
-                component={GroupScreen} 
-                options={{ title: 'Groups' }} />
+              <Stack.Screen name="Groups" component={GroupScreen} options={{ title: 'Groups' }} />
               <Stack.Screen
                 name="Cameras"
                 component={CameraScreen}
@@ -196,19 +205,19 @@ export default function App(): React.ReactElement {
                   headerShown: false,
                 }}
               />
-              <Stack.Screen 
-                name="Notifications" 
-                component={NotifScreen} 
+              <Stack.Screen
+                name="Notifications"
+                component={NotifScreen}
                 options={{
                   headerRight: () => null,
                 }}
               />
-              <Stack.Screen 
-                name="Snapshot" 
+              <Stack.Screen
+                name="Snapshot"
                 component={SnapshotScreen}
                 options={{
                   headerRight: () => null,
-                }} 
+                }}
               />
             </Stack.Navigator>
           </BackendContext.Provider>

--- a/app/human-detector-app/package-lock.json
+++ b/app/human-detector-app/package-lock.json
@@ -37,6 +37,7 @@
         "expo-system-ui": "~1.3.0",
         "expo-updates": "~0.14.6",
         "expo-web-browser": "~11.0.0",
+        "intl": "^1.2.5",
         "node-fetch": "^3.2.10",
         "react": "18.0.0",
         "react-dom": "18.0.0",
@@ -12391,6 +12392,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/intl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/intl/-/intl-1.2.5.tgz",
+      "integrity": "sha512-rK0KcPHeBFBcqsErKSpvZnrOmWOj+EmDkyJ57e90YWaQNqbcivcqmKDlHEeNprDWOsKzPsh1BfSpPQdDvclHVw=="
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -30771,6 +30777,11 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
+    },
+    "intl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/intl/-/intl-1.2.5.tgz",
+      "integrity": "sha512-rK0KcPHeBFBcqsErKSpvZnrOmWOj+EmDkyJ57e90YWaQNqbcivcqmKDlHEeNprDWOsKzPsh1BfSpPQdDvclHVw=="
     },
     "invariant": {
       "version": "2.2.4",

--- a/app/human-detector-app/package.json
+++ b/app/human-detector-app/package.json
@@ -52,6 +52,7 @@
     "expo-system-ui": "~1.3.0",
     "expo-updates": "~0.14.6",
     "expo-web-browser": "~11.0.0",
+    "intl": "^1.2.5",
     "node-fetch": "^3.2.10",
     "react": "18.0.0",
     "react-dom": "18.0.0",

--- a/app/human-detector-app/screens/NotifScreen.tsx
+++ b/app/human-detector-app/screens/NotifScreen.tsx
@@ -22,7 +22,9 @@ export default function NotifScreen({ navigation, route }: Props): React.ReactEl
                 navigation.navigate('Snapshot', { snapshotId: notification.snapshotId });
               }}
             >
-              <Text style={styles.menuButtonText}> {notification.timestamp.toString()} </Text>
+              <Text style={styles.menuButtonText}>
+                {notification.timestamp.toLocaleString(undefined, { hour12: true })}
+              </Text>
             </TouchableOpacity>
           </View>
         ))}


### PR DESCRIPTION
# Description
The notification timestamps looked pretty ugly before because they were ISO strings. Now, they print a shortened date with a locale timezone aware time with AM or PM.

![example](https://media.discordapp.net/attachments/525059324318318605/1047423916622229544/Screenshot_20221130-000748.png?width=502&height=892)